### PR TITLE
Delay loader initialization until caddy calls it

### DIFF
--- a/plugin/loader.go
+++ b/plugin/loader.go
@@ -10,19 +10,30 @@ import (
 
 // DockerLoader generates caddy files from docker swarm information
 type DockerLoader struct {
-	Input caddy.CaddyfileInput
+	Input       caddy.CaddyfileInput
+	Initialized bool
 }
 
 // CreateDockerLoader creates a docker loader
 func CreateDockerLoader() *DockerLoader {
-	loader := DockerLoader{
+	return &DockerLoader{
 		Input: caddy.CaddyfileInput{
 			ServerTypeName: "http",
 		},
 	}
-	loader.updateInput()
-	loader.scheduleUpdate()
-	return &loader
+}
+
+// Load returns the current caddy file input
+func (dockerLoader *DockerLoader) Load(serverType string) (caddy.Input, error) {
+	if serverType != "http" {
+		return nil, nil
+	}
+	if !dockerLoader.Initialized {
+		dockerLoader.Initialized = true
+		dockerLoader.updateInput()
+		dockerLoader.scheduleUpdate()
+	}
+	return dockerLoader.Input, nil
 }
 
 func (dockerLoader *DockerLoader) scheduleUpdate() {
@@ -43,16 +54,7 @@ func (dockerLoader *DockerLoader) updateInput() bool {
 
 	dockerLoader.Input.Contents = newContents
 
-	log.Println("[INFO] New CaddyFile:")
-	log.Println(string(dockerLoader.Input.Contents))
+	log.Printf("[INFO] New CaddyFile:\n%s", dockerLoader.Input.Contents)
 
 	return true
-}
-
-// Load returns the current caddy file input
-func (dockerLoader *DockerLoader) Load(serverType string) (caddy.Input, error) {
-	if serverType != "http" {
-		return nil, nil
-	}
-	return dockerLoader.Input, nil
 }


### PR DESCRIPTION
Loader was initialized before caddy invokes it, that was causing 2 problems:
- When run unit tests it was connecting to docker and printing to console
- It was always logging first caddyfile content to stdout, not respecting `-log file` caddy argument

@ibnesayeed