### PR TITLE
Add option to proxy service tasks instead of service VIP

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   - api/types/swarm
   - client
 - package: github.com/mholt/caddy
-  version: ^0.10.12
+  version: ^0.10.14
   subpackages:
   - caddy/caddymain
 testImport:

--- a/plugin/generator_test.go
+++ b/plugin/generator_test.go
@@ -138,7 +138,7 @@ func TestAddServiceWithTemplates(t *testing.T) {
 		"  }\n" +
 		"}\n"
 
-	testSingleService(t, service, expected)
+	testSingleService(t, false, service, expected)
 }
 
 func TestAddServiceWithBasicLabels(t *testing.T) {
@@ -172,7 +172,7 @@ func TestAddServiceWithBasicLabels(t *testing.T) {
 		"  }\n" +
 		"}\n"
 
-	testSingleService(t, service, expected)
+	testSingleService(t, false, service, expected)
 }
 
 func TestAddServiceWithBasicLabelsAndMultipleConfigs(t *testing.T) {
@@ -215,11 +215,32 @@ func TestAddServiceWithBasicLabelsAndMultipleConfigs(t *testing.T) {
 		"  }\n" +
 		"}\n"
 
-	testSingleService(t, service, expected)
+	testSingleService(t, false, service, expected)
 }
 
-func testSingleService(t *testing.T, service *swarm.Service, expected string) {
+func TestAddServiceProxyServiceTasks(t *testing.T) {
+	var service = &swarm.Service{
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name: "service",
+				Labels: map[string]string{
+					"caddy.address":    "service.testdomain.com",
+					"caddy.targetport": "5000",
+				},
+			},
+		},
+	}
+
+	const expected string = "service.testdomain.com {\n" +
+		"  proxy / tasks.service:5000\n" +
+		"}\n"
+
+	testSingleService(t, true, service, expected)
+}
+
+func testSingleService(t *testing.T, shouldProxyServiceTasks bool, service *swarm.Service, expected string) {
 	var buffer bytes.Buffer
+	proxyServiceTasks = shouldProxyServiceTasks
 	addServiceToCaddyFile(&buffer, service)
 	var content = buffer.String()
 	assert.Equal(t, expected, content)


### PR DESCRIPTION
I've been using the tasks dns instead of service VIP and it worked much more stable.

Sometimes I was getting a `no route` error and caddy can't reach the service VIP. I don't know the reason.