### PR TITLE
Skip services monitoring when swarm is not available

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ go test -race -v $(glide novendor)
 CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o caddy
 docker build -t lucaslorentz/caddy-docker-proxy:ci -f Dockerfile .
 docker build -t lucaslorentz/caddy-docker-proxy:ci-alpine -f Dockerfile-alpine .
+docker image tag lucaslorentz/caddy-docker-proxy:ci-alpine lucaslorentz/caddy-docker-proxy:test
 
 CGO_ENABLED=0 GOARCH=arm GOARM=6 GOOS=linux go build -o caddy
 docker build -t lucaslorentz/caddy-docker-proxy:ci-arm32v6 -f Dockerfile-arm32v6 .


### PR DESCRIPTION
Fixes https://github.com/lucaslorentz/caddy-docker-proxy/issues/59
@ptman what do you think?

I'm not sure if we should check swarm availability only once and cache it.
Or if we should check it every time, that way if the node is disconnected from swarm we nicely handle that with a comment on Caddyfile instead of errors.