### PR TITLE
Sort directives by their names

### DIFF
--- a/plugin/generator_test.go
+++ b/plugin/generator_test.go
@@ -426,7 +426,10 @@ func testSingleService(t *testing.T, shouldProxyServiceTasks bool, service *swar
 	})
 	generator.caddyNetworks = map[string]bool{}
 	generator.caddyNetworks[caddyNetworkID] = true
-	generator.addServiceToCaddyFile(&buffer, service)
+	dContent := generator.addServiceToCaddyFile(service)
+	for _, d := range dContent {
+		buffer.Write(d.content.Bytes())
+	}
 	var content = buffer.String()
 	assert.Equal(t, expected, content)
 }
@@ -439,7 +442,10 @@ func testSingleContainer(t *testing.T, container *types.Container, expected stri
 	})
 	generator.caddyNetworks = map[string]bool{}
 	generator.caddyNetworks[caddyNetworkID] = true
-	generator.addContainerToCaddyFile(&buffer, container)
+	dContent := generator.addContainerToCaddyFile(container)
+	for _, d := range dContent {
+		buffer.Write(d.content.Bytes())
+	}
 	var content = buffer.String()
 	assert.Equal(t, expected, content)
 }


### PR DESCRIPTION
This PR implements directives sorting useful when using Caddy [snippets](https://caddyserver.com/docs/caddyfile#snippets) and imports because the snippets must be defined before the directive which is importing it. This is especially useful when the snippets are coming from a different node that the directive. Luckily the snippets always start with `(` which puts them at the top of the sorted list.