### PR TITLE
Default proxy target port to caddy default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Those are the main labels that configures the basic behavior of the proxying:
 | Label | Example | Description | Required |
 | - | - | - | - |
 | caddy.address | service.example.com | addresses that should be proxied separated by whitespace | Required |
-| caddy.targetport | 80 | the port being server by container | Required |
-| caddy.targetpath | /api | the path being served by container | Required |
+| caddy.targetport | 80 | the port being server by container | Optional |
+| caddy.targetpath | /api | the path being served by container | Optional |
 | caddy.targetprotocol | https | the protocol being served by container | Optional |
 
 When added to a service, the values above will generate the following caddy configuration:

--- a/plugin/generator.go
+++ b/plugin/generator.go
@@ -261,14 +261,14 @@ func (g *CaddyfileGenerator) parseDirectives(labels map[string]string, templateD
 	//Convert basic labels
 	for _, directive := range rootDirective.children {
 		address := directive.children["address"]
+
 		if address != nil {
 			directive.name = address.args
-		}
 
-		targetPort := directive.children["targetport"]
-		targetPath := directive.children["targetpath"]
-		targetProtocol := directive.children["targetprotocol"]
-		if targetPort != nil || targetProtocol != nil {
+			targetPort := directive.children["targetport"]
+			targetPath := directive.children["targetpath"]
+			targetProtocol := directive.children["targetprotocol"]
+
 			proxyDirective := getOrCreateDirective(directive, "proxy")
 			proxyTarget, err := getProxyTarget()
 			if err != nil {
@@ -281,7 +281,11 @@ func (g *CaddyfileGenerator) parseDirectives(labels map[string]string, templateD
 				proxyDirective.args += targetProtocol.args + "://"
 			}
 
-			proxyDirective.args += fmt.Sprintf("%s:%s", proxyTarget, targetPort.args)
+			proxyDirective.args += proxyTarget
+
+			if targetPort != nil {
+				proxyDirective.args += ":" + targetPort.args
+			}
 
 			if targetPath != nil {
 				proxyDirective.args += targetPath.args

--- a/plugin/generator_test.go
+++ b/plugin/generator_test.go
@@ -62,20 +62,18 @@ func TestAddContainerWithBasicLabels(t *testing.T) {
 			},
 		},
 		Labels: map[string]string{
-			fmtLabel("%s.address"):    "service.testdomain.com",
-			fmtLabel("%s.targetport"): "5000",
-			fmtLabel("%s.targetpath"): "/api",
+			fmtLabel("%s.address"): "service.testdomain.com",
 		},
 	}
 
 	const expected string = "service.testdomain.com {\n" +
-		"  proxy / 172.17.0.2:5000/api\n" +
+		"  proxy / 172.17.0.2\n" +
 		"}\n"
 
 	testSingleContainer(t, container, expected)
 }
 
-func TestAddContainerWithBasicLabelsAndHttps(t *testing.T) {
+func TestAddContainerWithBasicLabelsProtocolAndPort(t *testing.T) {
 	var container = &types.Container{
 		NetworkSettings: &types.SummaryNetworkSettings{
 			Networks: map[string]*network.EndpointSettings{
@@ -225,8 +223,6 @@ func TestAddServiceWithBasicLabels(t *testing.T) {
 				Name: "service",
 				Labels: map[string]string{
 					fmtLabel("%s.address"):            "service.testdomain.com",
-					fmtLabel("%s.targetport"):         "5000",
-					fmtLabel("%s.targetpath"):         "/api",
 					fmtLabel("%s.proxy.health_check"): "/health",
 					fmtLabel("%s.proxy.transparent"):  "",
 					fmtLabel("%s.proxy.websocket"):    "",
@@ -246,7 +242,7 @@ func TestAddServiceWithBasicLabels(t *testing.T) {
 
 	const expected string = "service.testdomain.com {\n" +
 		"  basicauth / user password\n" +
-		"  proxy / service:5000/api {\n" +
+		"  proxy / service {\n" +
 		"    health_check /health\n" +
 		"    transparent\n" +
 		"    websocket\n" +
@@ -259,7 +255,7 @@ func TestAddServiceWithBasicLabels(t *testing.T) {
 	testSingleService(t, false, service, expected)
 }
 
-func TestAddServiceWithBasicLabelsAndHttps(t *testing.T) {
+func TestAddServiceWithBasicLabelsProtocolAndPort(t *testing.T) {
 	var service = &swarm.Service{
 		Spec: swarm.ServiceSpec{
 			Annotations: swarm.Annotations{


### PR DESCRIPTION
Fixes: https://github.com/lucaslorentz/caddy-docker-proxy/issues/12

It's not possible to retrieve ports from docker service, we need a container instance to know it, and containers might not run on the manager we're running caddy proxy. So, checking the available ports brings unnecessary complexities.

This PR makes label `caddy.targetport` optional, and generates proxy directives without port, like:
```
proxy service_name
```

You can still override protocol with label `caddy.targetprotocol`, and can override port with label `caddy.targetport` and path with label `caddy.targetpath`. That generates directives like:
```
proxy protocol://service_name:port/path
```

Caddy will default protocol to http.
And then it will default port to protocol default port (http: 80, https: 443).
https://caddyserver.com/docs/proxy
