### PR TITLE
Added builds that have telemetry disabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ RUN apk add -U --no-cache ca-certificates
 FROM scratch
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 
+ARG CADDY_EXEC=caddy 
+
 EXPOSE 80 443 2015
 ENV HOME /root
 
 WORKDIR /
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY artifacts/binaries/linux/amd64/caddy /bin/
+COPY artifacts/binaries/linux/amd64/$CADDY_EXEC /bin/caddy
 
 ENTRYPOINT ["/bin/caddy"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,10 +1,12 @@
 FROM alpine:3.7
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 
+ARG CADDY_EXEC=caddy 
+
 EXPOSE 80 443 2015
 
 RUN apk add --no-cache ca-certificates curl
 
-COPY artifacts/binaries/linux/amd64/caddy /bin/
+COPY artifacts/binaries/linux/amd64/$CADDY_EXEC /bin/caddy
 
 ENTRYPOINT ["/bin/caddy"]

--- a/Dockerfile-alpine-arm32v6
+++ b/Dockerfile-alpine-arm32v6
@@ -5,10 +5,12 @@ RUN apk add -U --no-cache ca-certificates
 FROM arm32v6/alpine:3.7
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 
+ARG CADDY_EXEC=caddy 
+
 EXPOSE 80 443 2015
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY artifacts/binaries/linux/arm32v6/caddy /bin/
+COPY artifacts/binaries/linux/arm32v6/$CADDY_EXEC /bin/caddy
 
 ENTRYPOINT ["/bin/caddy"]

--- a/Dockerfile-arm32v6
+++ b/Dockerfile-arm32v6
@@ -5,12 +5,14 @@ RUN apk add -U --no-cache ca-certificates
 FROM scratch
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 
+ARG CADDY_EXEC=caddy 
+
 EXPOSE 80 443 2015
 ENV HOME /root
 
 WORKDIR /
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY artifacts/binaries/linux/arm32v6/caddy /bin/
+COPY artifacts/binaries/linux/arm32v6/$CADDY_EXEC /bin/caddy
 
 ENTRYPOINT ["/bin/caddy"]

--- a/Dockerfile-nanoserver-1803
+++ b/Dockerfile-nanoserver-1803
@@ -1,8 +1,10 @@
 FROM microsoft/nanoserver:1803
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 
+ARG CADDY_EXEC=caddy 
+
 EXPOSE 80 443 2015
 
-COPY artifacts/binaries/windows/amd64/caddy.exe "C:\\caddy.exe"
+COPY artifacts/binaries/windows/amd64/$CADDY_EXEC.exe "C:\\caddy.exe"
 
 ENTRYPOINT ["C:\\caddy.exe"]

--- a/build-images-linux.sh
+++ b/build-images-linux.sh
@@ -6,6 +6,14 @@ chmod +x artifacts/binaries/linux/amd64/caddy
 docker build -t lucaslorentz/caddy-docker-proxy:ci -f Dockerfile .
 docker build -t lucaslorentz/caddy-docker-proxy:ci-alpine -f Dockerfile-alpine .
 
+chmod +x artifacts/binaries/linux/amd64/caddy-no-telemetry
+docker build -t lucaslorentz/caddy-docker-proxy:ci-no-telemetry -f Dockerfile --build-arg CADDY_EXEC=caddy-no-telemetry .
+docker build -t lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine -f Dockerfile-alpine --build-arg CADDY_EXEC=caddy-no-telemetry .
+
 chmod +x artifacts/binaries/linux/arm32v6/caddy
 docker build -t lucaslorentz/caddy-docker-proxy:ci-arm32v6 -f Dockerfile-arm32v6 .
 docker build -t lucaslorentz/caddy-docker-proxy:ci-alpine-arm32v6 -f Dockerfile-alpine-arm32v6 .
+
+chmod +x artifacts/binaries/linux/arm32v6/caddy-no-telemetry
+docker build -t lucaslorentz/caddy-docker-proxy:ci-no-telemetry-arm32v6 -f Dockerfile-arm32v6 --build-arg CADDY_EXEC=caddy-no-telemetry .
+docker build -t lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine-arm32v6 -f Dockerfile-alpine-arm32v6 --build-arg CADDY_EXEC=caddy-no-telemetry .

--- a/build-images-windows.sh
+++ b/build-images-windows.sh
@@ -3,3 +3,4 @@
 set -e
 
 docker build -t lucaslorentz/caddy-docker-proxy:ci-nanoserver-1803 -f Dockerfile-nanoserver-1803 .
+docker build -t lucaslorentz/caddy-docker-proxy:ci-no-telemetry-nanoserver-1803 -f Dockerfile-nanoserver-1803 --build-arg CADDY_EXEC=caddy-no-telemetry .

--- a/build.sh
+++ b/build.sh
@@ -13,3 +13,7 @@ go test -race -v $(glide novendor)
 CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o ${ARTIFACTS}/binaries/linux/amd64/caddy
 CGO_ENABLED=0 GOARCH=arm GOARM=6 GOOS=linux go build -o ${ARTIFACTS}/binaries/linux/arm32v6/caddy
 CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -o ${ARTIFACTS}/binaries/windows/amd64/caddy.exe
+
+CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags "-X main.DisableTelemetryFlag=true" -o ${ARTIFACTS}/binaries/linux/amd64/caddy-no-telemetry
+CGO_ENABLED=0 GOARCH=arm GOARM=6 GOOS=linux go build -ldflags "-X main.DisableTelemetryFlag=true" -o ${ARTIFACTS}/binaries/linux/arm32v6/caddy-no-telemetry
+CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -ldflags "-X main.DisableTelemetryFlag=true" -o ${ARTIFACTS}/binaries/windows/amd64/caddy-no-telemetry.exe

--- a/main.go
+++ b/main.go
@@ -10,7 +10,14 @@ import (
 	"github.com/mholt/caddy/caddy/caddymain"
 )
 
+// DisableTelemetryFlag if set, it will disable telemetry that Caddy enables by default
+var DisableTelemetryFlag string
+
 func main() {
+	if DisableTelemetryFlag != "" {
+		caddymain.EnableTelemetry = false
+	}
+
 	caddymain.Run()
 
 	// Keep caddy running after main instance is stopped

--- a/push-images-linux.sh
+++ b/push-images-linux.sh
@@ -9,6 +9,11 @@ docker push lucaslorentz/caddy-docker-proxy:ci-alpine
 docker push lucaslorentz/caddy-docker-proxy:ci-arm32v6
 docker push lucaslorentz/caddy-docker-proxy:ci-alpine-arm32v6
 
+docker push lucaslorentz/caddy-docker-proxy:ci-no-telemetry
+docker push lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine
+docker push lucaslorentz/caddy-docker-proxy:ci-no-telemetry-arm32v6
+docker push lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine-arm32v6
+
 if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
     echo "Releasing version ${RELEASE_VERSION}..."
 
@@ -23,6 +28,13 @@ if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
     docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}
     docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}
 
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry lucaslorentz/caddy-docker-proxy:no-telemetry
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry
+    docker push lucaslorentz/caddy-docker-proxy:no-telemetry
+    docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry
+    docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry
+
     # alpine
     docker tag lucaslorentz/caddy-docker-proxy:ci-alpine lucaslorentz/caddy-docker-proxy:alpine
     docker tag lucaslorentz/caddy-docker-proxy:ci-alpine lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-alpine
@@ -30,6 +42,13 @@ if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
     docker push lucaslorentz/caddy-docker-proxy:alpine
     docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-alpine
     docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-alpine
+
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine lucaslorentz/caddy-docker-proxy:no-telemetry-alpine
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-alpine
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-alpine
+    docker push lucaslorentz/caddy-docker-proxy:no-telemetry-alpine
+    docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-alpine
+    docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-alpine
 
     # scratch arm32v6
     docker tag lucaslorentz/caddy-docker-proxy:ci-arm32v6 lucaslorentz/caddy-docker-proxy:latest-arm32v6
@@ -39,6 +58,13 @@ if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
     docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-arm32v6
     docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-arm32v6
 
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-arm32v6 lucaslorentz/caddy-docker-proxy:no-telemetry-arm32v6
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-arm32v6 lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-arm32v6
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-arm32v6 lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-arm32v6
+    docker push lucaslorentz/caddy-docker-proxy:no-telemetry-arm32v6
+    docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-arm32v6
+    docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-arm32v6
+
     # alpine arm32v6
     docker tag lucaslorentz/caddy-docker-proxy:ci-alpine-arm32v6 lucaslorentz/caddy-docker-proxy:alpine-arm32v6
     docker tag lucaslorentz/caddy-docker-proxy:ci-alpine-arm32v6 lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-alpine-arm32v6
@@ -46,4 +72,11 @@ if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
     docker push lucaslorentz/caddy-docker-proxy:alpine-arm32v6
     docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-alpine-arm32v6
     docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-alpine-arm32v6
+
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine-arm32v6 lucaslorentz/caddy-docker-proxy:no-telemetry-alpine-arm32v6
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine-arm32v6 lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-alpine-arm32v6
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-alpine-arm32v6 lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-alpine-arm32v6
+    docker push lucaslorentz/caddy-docker-proxy:no-telemetry-alpine-arm32v6
+    docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-alpine-arm32v6
+    docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-alpine-arm32v6
 fi

--- a/push-images-windows.sh
+++ b/push-images-windows.sh
@@ -21,4 +21,11 @@ if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
     docker push lucaslorentz/caddy-docker-proxy:nanoserver-1803
     docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-nanoserver-1803
     docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-nanoserver-1803
+
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-nanoserver-1803 lucaslorentz/caddy-docker-proxy:no-telemetry-nanoserver-1803
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-nanoserver-1803 lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-nanoserver-1803
+    docker tag lucaslorentz/caddy-docker-proxy:ci-no-telemetry-nanoserver-1803 lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-nanoserver-1803
+    docker push lucaslorentz/caddy-docker-proxy:no-telemetry-nanoserver-1803
+    docker push lucaslorentz/caddy-docker-proxy:${PATCH_VERSION}-no-telemetry-nanoserver-1803
+    docker push lucaslorentz/caddy-docker-proxy:${MINOR_VERSION}-no-telemetry-nanoserver-1803
 fi


### PR DESCRIPTION
Add no-telemetry builds for all of the various `caddy-docker-proxy` images. Fixes https://github.com/lucaslorentz/caddy-docker-proxy/issues/85.