### PR TITLE
Fake NULL Values

### DIFF
--- a/plugin/generator.go
+++ b/plugin/generator.go
@@ -416,13 +416,13 @@ func processVariables(data interface{}, content string) string {
 }
 
 func parseArgs(text string) []string {
+	text = strings.Replace(text, "[0xNULLx0]", "", -1)
 	args := regSplit(text, "\\s+")
 	if len(args) == 1 && args[0] == "" {
 		return []string{}
 	}
 	return args
 }
-
 func regSplit(text string, delimeter string) []string {
 	reg := regexp.MustCompile(delimeter)
 	indexes := reg.FindAllStringIndex(text, -1)


### PR DESCRIPTION
Some container management solutions don't allow NULL or empty string label values. An example is portainer (https://github.com/portainer/portainer/issues/2646).

This patch creates a faux NULL value that's replaced during label processing to ensure that NULL value parameters can be passed through the parsing engine despite upstream not allowing such.

This has been tested with Portainer 1.2.0 using a custom caddy build to ensure correctness.

The value chosen is ```[0xNULLx0]``` and that's wholly invalid generally speaking per the Caddyfile syntax.