### PR TITLE
Disable telemetry by default with options to enable it back

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ CADDY_DOCKER_POLLING_INTERVAL=<duration>
 CADDY_DOCKER_PROXY_SERVICE_TASKS=<bool>
 ```
 
+## Caddy Telemetry
+
+We decided to disable telemetry by default in caddy-docker-proxy images. You can enable telemetry by setting environment variable **CADDY_ENABLE_TELEMETRY** to **true**. Or with CLI option **-enable-telemetry**.
+
 ## Connecting to Docker Host
 The default connection to docker host varies per platform:
 * At Unix: `unix:///var/run/docker.sock`

--- a/main.go
+++ b/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"flag"
+	"os"
+	"regexp"
+
 	// Plugins
 	_ "github.com/lucaslorentz/caddy-docker-proxy/plugin"
 
@@ -19,7 +23,20 @@ import (
 	"github.com/mholt/caddy/caddy/caddymain"
 )
 
+var enableTelemetryFlag bool
+var isTrue = regexp.MustCompile("(?i)^(true|yes|1)$")
+
 func main() {
+	flag.BoolVar(&enableTelemetryFlag, "enable-telemetry", false, "Enable caddy telemetry")
+
+	flag.Parse()
+
+	if enableTelemetryEnv := os.Getenv("CADDY_ENABLE_TELEMETRY"); enableTelemetryEnv != "" {
+		caddymain.EnableTelemetry = isTrue.MatchString(enableTelemetryEnv)
+	} else {
+		caddymain.EnableTelemetry = enableTelemetryFlag
+	}
+
 	caddymain.Run()
 
 	// Keep caddy running after main instance is stopped


### PR DESCRIPTION
Fixing issue https://github.com/lucaslorentz/caddy-docker-proxy/issues/85