### PR TITLE
 Update the import paths for Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ docker stack rm caddy-docker-demo
 ## Building it
 You can use our caddy build wrapper **build.sh** and include additional plugins on https://github.com/lucaslorentz/caddy-docker-proxy/blob/master/main.go#L5
 
-Or, you can build from caddy repository and import  **caddy-docker-proxy** plugin on file https://github.com/mholt/caddy/blob/master/caddy/caddymain/run.go :
+Or, you can build from caddy repository and import  **caddy-docker-proxy** plugin on file https://github.com/caddyserver/caddy/blob/master/caddy/caddymain/run.go :
 ```
 import (
   _ "github.com/lucaslorentz/caddy-docker-proxy/plugin"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.1 // indirect
 	github.com/caddyserver/caddy v1.0.1
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
-	github.com/nicolasazrak/caddy-cache v1.3.4
+	github.com/nicolasazrak/caddy-cache v0.3.4
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/aws/aws-sdk-go v1.19.19 // indirect
-	github.com/caddyserver/dnsproviders v0.1.4
+	github.com/caddyserver/dnsproviders v0.3.0
 	github.com/cloudflare/cloudflare-go v0.9.0 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190427035354-32daacb40dd6

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/gorilla/mux v1.7.1 // indirect
-	github.com/mholt/caddy v1.0.0
+	github.com/caddyserver/caddy v1.0.1
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/nicolasazrak/caddy-cache v0.3.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.1 // indirect
 	github.com/caddyserver/caddy v1.0.1
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
-	github.com/nicolasazrak/caddy-cache v0.3.1
+	github.com/nicolasazrak/caddy-cache 0540bb00038bb0a61528d939387470c3ee10bcef
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
@@ -31,3 +31,5 @@ require (
 	google.golang.org/grpc v1.20.1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+replace github.com/h2non/gock => gopkg.in/h2non/gock.v1 v1.0.14

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.1 // indirect
 	github.com/caddyserver/caddy v1.0.1
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
-	github.com/nicolasazrak/caddy-cache 0540bb00038bb0a61528d939387470c3ee10bcef
+	github.com/nicolasazrak/caddy-cache v1.3.4
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	_ "github.com/nicolasazrak/caddy-cache"
 
 	// Caddy
-	"github.com/mholt/caddy/caddy/caddymain"
+	"github.com/caddyserver/caddy/caddy/caddymain"
 )
 
 var enableTelemetryFlag bool

--- a/plugin/loader.go
+++ b/plugin/loader.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 var pollingInterval = 30 * time.Second

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func init() {

--- a/plugin/reloadcaddy_posix.go
+++ b/plugin/reloadcaddy_posix.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func ReloadCaddy(loader caddy.Loader) {

--- a/plugin/reloadcaddy_windows.go
+++ b/plugin/reloadcaddy_windows.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 
-	httpserver "github.com/mholt/caddy/caddyhttp/httpserver"
+	httpserver "github.com/caddyserver/caddy/caddyhttp/httpserver"
 )
 
 // ReloadCaddy reloads caddy


### PR DESCRIPTION
This pull request makes caddy-docker-proxy compatible with Caddy v1.0.1+ (see https://github.com/epicagency/caddy-expires/issues/6 for reference) by updating the import paths for Caddy and by bumping the version of the dnsproviders and caddy-cache plugins.