### PR TITLE
Add 1809 docker images

### DIFF
--- a/Dockerfile-nanoserver-1809
+++ b/Dockerfile-nanoserver-1809
@@ -1,0 +1,8 @@
+FROM microsoft/nanoserver:1803
+LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
+
+EXPOSE 80 443 2015
+
+COPY artifacts/binaries/windows/amd64/caddy.exe "C:\\caddy.exe"
+
+ENTRYPOINT ["C:\\caddy.exe"]

--- a/Dockerfile-nanoserver-1809
+++ b/Dockerfile-nanoserver-1809
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:1803
+FROM microsoft/nanoserver:1809
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 
 EXPOSE 80 443 2015

--- a/build-images-windows.sh
+++ b/build-images-windows.sh
@@ -3,3 +3,4 @@
 set -e
 
 docker build -t lucaslorentz/caddy-docker-proxy:ci-nanoserver-1803 -f Dockerfile-nanoserver-1803 .
+docker build -t lucaslorentz/caddy-docker-proxy:ci-nanoserver-1809 -f Dockerfile-nanoserver-1809 .


### PR DESCRIPTION
Currently, you only have processes to build images for nanoserver 1803.  Unless the container host is setup to use hyperv isolation, these images will only work on a fairly narrow set of container hosts, as neither Server 2016 nor Server 2019 can run these images.  In my quick testing, using process isolation, Windows 10 1909 will run nanoserver 1809, 1903, and 1909, but not 1803.  Server 2016 will not run any of these, and Server 2019 will only run 1809.  Given that most server container hosts will either be running Server 2016 or Server 2019, adding nanoserver 1809 as an image would allow a significantly larger user base to make use of the images.

I am creating this as a draft release, because I am unsure what would need to be done to the azure pipelines file to allow the builds to work.  It appears that it is being built on a nanoserver 1803 agent, and would require at minimum version of either nanoserver 1809 or server core 2019 to build the 1809 image, and likely require hyperv support to continue building the 1803 version, or require using two different agents.