### PR TITLE
Refactor tests to use test files for input/expected pairs

### DIFF
--- a/plugin/caddyfile/fromlabels_test.go
+++ b/plugin/caddyfile/fromlabels_test.go
@@ -1,175 +1,106 @@
 package caddyfile
 
 import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFromLabels_Grouping(t *testing.T) {
-	labels := map[string]string{
-		"caddy":               "localhost",
-		"caddy.group.a":       "value-a",
-		"caddy.group.b":       "value-b",
-		"caddy.group.group.a": "value-a",
-		"caddy.group.group.b": "value-b",
+func TestLabelsToCaddyfile(t *testing.T) {
+	// load the list of test files from the dir
+	files, err := ioutil.ReadDir("./testdata/labels")
+	if err != nil {
+		t.Errorf("failed to read labels dir: %s", err)
 	}
 
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
+	// prep a regexp to fix strings on windows
+	winNewlines := regexp.MustCompile(`\r?\n`)
 
-	const expectedCaddyfile = "localhost {\n" +
-		"	group {\n" +
-		"		a value-a\n" +
-		"		b value-b\n" +
-		"		group {\n" +
-		"			a value-a\n" +
-		"			b value-b\n" +
-		"		}\n" +
-		"	}\n" +
-		"}\n"
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
 
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
+		// read the test file
+		filename := f.Name()
+		data, err := ioutil.ReadFile("./testdata/labels/" + filename)
+		if err != nil {
+			t.Errorf("failed to read %s dir: %s", filename, err)
+		}
+
+		// split the labels (first) and Caddyfile (second) parts
+		parts := strings.Split(string(data), "----------")
+		labelsString, expectedCaddyfile := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+
+		// parse label key-value pairs
+		labels, err := parseLabelsFromString(labelsString)
+		if err != nil {
+			t.Errorf("failed to parse labels from %s", filename)
+		}
+
+		// replace windows newlines in the json with unix newlines
+		expectedCaddyfile = winNewlines.ReplaceAllString(expectedCaddyfile, "\n")
+
+		// convert the labels to a Caddyfile
+		caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
+
+		// if the result is nil then we expect an empty Caddyfile
+		if caddyfileBlock == nil {
+			if expectedCaddyfile != "" {
+				t.Errorf("got nil in %s but expected: %s", filename, expectedCaddyfile)
+			}
+			continue
+		}
+
+		// if caddyfileBlock is not nil, we expect no error
+		assert.NoError(t, err, "expected no error in %s", filename)
+
+		// compare the actual and expected Caddyfiles
+		actualCaddyfile := strings.TrimSpace(caddyfileBlock.MarshalString())
+		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
+			"comparison failed in %s: \nExpected:\n%s\n\nActual:\n%s\n",
+			filename, expectedCaddyfile, actualCaddyfile)
+	}
 }
 
-func TestFromLabels_FollowAlphabeticalOrder(t *testing.T) {
-	labels := map[string]string{
-		"caddy":     "localhost",
-		"caddy.bbb": "value",
-		"caddy.aaa": "value",
+func parseLabelsFromString(s string) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	lines := strings.Split(s, "\n")
+	lineNumber := 0
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		lineNumber++
+
+		// skip lines starting with comment
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// skip empty line
+		if len(line) == 0 {
+			continue
+		}
+
+		fields := strings.SplitN(line, "=", 2)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("can't parse line %d; line should be in KEY = VALUE format", lineNumber)
+		}
+
+		key := strings.TrimSpace(fields[0])
+		val := strings.TrimSpace(fields[1])
+
+		if key == "" {
+			return nil, fmt.Errorf("missing or empty key on line %d", lineNumber)
+		}
+		labels[key] = val
 	}
 
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "localhost {\n" +
-		"	aaa value\n" +
-		"	bbb value\n" +
-		"}\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
-}
-
-func TestFromLabels_OrderDirectivesWithPrefix(t *testing.T) {
-	labels := map[string]string{
-		"caddy":       "localhost",
-		"caddy.1_bbb": "value",
-		"caddy.2_aaa": "value",
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "localhost {\n" +
-		"	bbb value\n" +
-		"	aaa value\n" +
-		"}\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
-}
-
-func TestFromLabels_SeparateDirectivesWithSuffix(t *testing.T) {
-	labels := map[string]string{
-		"caddy":           "localhost",
-		"caddy.group_1.a": "value",
-		"caddy.group_2.b": "value",
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "localhost {\n" +
-		"	group {\n" +
-		"		a value\n" +
-		"	}\n" +
-		"	group {\n" +
-		"		b value\n" +
-		"	}\n" +
-		"}\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
-}
-
-func TestFromLabels_TemplatesEmptyValues(t *testing.T) {
-	labels := map[string]string{
-		"caddy":     "localhost",
-		"caddy.key": `{{""}}`,
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "localhost {\n" +
-		"	key\n" +
-		"}\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
-}
-
-func TestFromLabels_TemplateError(t *testing.T) {
-	labels := map[string]string{
-		"caddy.key": "{{invalid}}",
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = ""
-
-	assert.Error(t, err)
-	assert.Nil(t, caddyfileBlock)
-}
-
-func TestFromLabels_GlobalDirectives(t *testing.T) {
-	labels := map[string]string{
-		"caddy.key": "value",
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "key value\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
-}
-
-func TestFromLabels_SnippetsComesFirst(t *testing.T) {
-	labels := map[string]string{
-		"caddy_0":        "aaa.com",
-		"caddy_0.import": "my-snippet",
-		"caddy_1":        "(my-snippet)",
-		"caddy_1.tls":    "internal",
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "(my-snippet) {\n" +
-		"	tls internal\n" +
-		"}\n" +
-		"aaa.com {\n" +
-		"	import my-snippet\n" +
-		"}\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
-}
-
-func TestFromLabels_MatchersComesFirst(t *testing.T) {
-	labels := map[string]string{
-		"caddy":               "localhost",
-		"caddy.@matcher.path": "/path1 /path2",
-		"caddy.respond":       "@matcher 200",
-	}
-
-	caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
-
-	const expectedCaddyfile = "localhost {\n" +
-		"	@matcher {\n" +
-		"		path /path1 /path2\n" +
-		"	}\n" +
-		"	respond @matcher 200\n" +
-		"}\n"
-
-	assert.NoError(t, err)
-	assert.Equal(t, expectedCaddyfile, caddyfileBlock.MarshalString())
+	return labels, nil
 }

--- a/plugin/caddyfile/processor_test.go
+++ b/plugin/caddyfile/processor_test.go
@@ -1,6 +1,9 @@
 package caddyfile
 
 import (
+	"io/ioutil"
+	"regexp"
+	"strings"
 	"testing"
 
 	_ "github.com/caddyserver/caddy/v2/modules/standard" // plug standard HTTP modules
@@ -8,45 +11,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProcess(t *testing.T) {
-	input := "(mysnippet) {\n" +
-		"	encode gzip\n" +
-		"}\n" +
-		"service1.example.com {\n" +
-		"	reverse_proxy service1:5000 {\n" +
-		"		invalid\n" +
-		"	}\n" +
-		"}\n" +
-		"service2.example.com {\n" +
-		"	respond 200 /\n" +
-		"	#Coment\n" +
-		"	reverse_proxy service2:5000 {\n" +
-		"		health_path /health\n" +
-		"	}\n" +
-		"	import mysnippet\n" +
-		"}\n" +
-		"service3.example.com {\n" +
-		"	respond 404 /\n" +
-		"	basicauth /secret {\n" +
-		"		user \" a \\ b\"\n" +
-		"	}\n" +
-		"}\n"
+func TestProcessCaddyfile(t *testing.T) {
+	// load the list of test files from the dir
+	files, err := ioutil.ReadDir("./testdata/process")
+	if err != nil {
+		t.Errorf("failed to read process dir: %s", err)
+	}
 
-	expected := "service2.example.com {\n" +
-		"	respond 200 /\n" +
-		"	reverse_proxy service2:5000 {\n" +
-		"		health_path /health\n" +
-		"	}\n" +
-		"	encode gzip\n" +
-		"}\n" +
-		"service3.example.com {\n" +
-		"	respond 404 /\n" +
-		"	basicauth /secret {\n" +
-		"		user \" a \\ b\"\n" +
-		"	}\n" +
-		"}\n"
+	// prep a regexp to fix strings on windows
+	winNewlines := regexp.MustCompile(`\r?\n`)
 
-	result, _ := Process([]byte(input))
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
 
-	assert.Equal(t, expected, string(result))
+		// read the test file
+		filename := f.Name()
+		data, err := ioutil.ReadFile("./testdata/process/" + filename)
+		if err != nil {
+			t.Errorf("failed to read %s dir: %s", filename, err)
+		}
+
+		// split two Caddyfile parts
+		parts := strings.Split(string(data), "----------")
+		beforeCaddyfile, expectedCaddyfile := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+
+		// replace windows newlines in the json with unix newlines
+		expectedCaddyfile = winNewlines.ReplaceAllString(expectedCaddyfile, "\n")
+
+		// process the Caddyfile
+		result, _ := Process([]byte(beforeCaddyfile))
+
+		actualCaddyfile := strings.TrimSpace(string(result))
+
+		// compare the actual and expected Caddyfiles
+		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
+			"failed to process in %s, \nExpected:\n%s\nActual:\n%s",
+			filename, expectedCaddyfile, actualCaddyfile)
+	}
 }

--- a/plugin/caddyfile/testdata/labels/follow_alphabetical_order.txt
+++ b/plugin/caddyfile/testdata/labels/follow_alphabetical_order.txt
@@ -1,0 +1,8 @@
+caddy     = localhost
+caddy.bbb = value
+caddy.aaa = value
+----------
+localhost {
+	aaa value
+	bbb value
+}

--- a/plugin/caddyfile/testdata/labels/global_options.txt
+++ b/plugin/caddyfile/testdata/labels/global_options.txt
@@ -1,0 +1,3 @@
+caddy.key = value
+----------
+key value

--- a/plugin/caddyfile/testdata/labels/grouping.txt
+++ b/plugin/caddyfile/testdata/labels/grouping.txt
@@ -1,0 +1,16 @@
+caddy               = localhost
+caddy.group.a       = value-a
+caddy.group.b       = value-b
+caddy.group.group.a = value-a
+caddy.group.group.b = value-b
+----------
+localhost {
+	group {
+		a value-a
+		b value-b
+		group {
+			a value-a
+			b value-b
+		}
+	}
+}

--- a/plugin/caddyfile/testdata/labels/matchers_come_first.txt
+++ b/plugin/caddyfile/testdata/labels/matchers_come_first.txt
@@ -1,0 +1,10 @@
+caddy               = localhost
+caddy.@matcher.path = /path1 /path2
+caddy.respond       = @matcher 200
+----------
+localhost {
+	@matcher {
+		path /path1 /path2
+	}
+	respond @matcher 200
+}

--- a/plugin/caddyfile/testdata/labels/order_directives_with_prefix.txt
+++ b/plugin/caddyfile/testdata/labels/order_directives_with_prefix.txt
@@ -1,0 +1,8 @@
+caddy       = localhost
+caddy.1_bbb = value
+caddy.2_aaa = value
+----------
+localhost {
+	bbb value
+	aaa value
+}

--- a/plugin/caddyfile/testdata/labels/separate_directives_with_suffix.txt
+++ b/plugin/caddyfile/testdata/labels/separate_directives_with_suffix.txt
@@ -1,0 +1,12 @@
+caddy           = localhost
+caddy.group_1.a = value
+caddy.group_2.b = value
+----------
+localhost {
+	group {
+		a value
+	}
+	group {
+		b value
+	}
+}

--- a/plugin/caddyfile/testdata/labels/snippets_come_first.txt
+++ b/plugin/caddyfile/testdata/labels/snippets_come_first.txt
@@ -1,0 +1,11 @@
+caddy_0        = aaa.com
+caddy_0.import = my-snippet
+caddy_1        = (my-snippet)
+caddy_1.tls    = internal
+----------
+(my-snippet) {
+	tls internal
+}
+aaa.com {
+	import my-snippet
+}

--- a/plugin/caddyfile/testdata/labels/template_error.txt
+++ b/plugin/caddyfile/testdata/labels/template_error.txt
@@ -1,0 +1,2 @@
+caddy.key = {{invalid}}
+----------

--- a/plugin/caddyfile/testdata/labels/templates_empty_values.txt
+++ b/plugin/caddyfile/testdata/labels/templates_empty_values.txt
@@ -1,0 +1,6 @@
+caddy     = localhost
+caddy.key = {{""}}
+----------
+localhost {
+	key
+}

--- a/plugin/caddyfile/testdata/process/process.txt
+++ b/plugin/caddyfile/testdata/process/process.txt
@@ -1,0 +1,36 @@
+(mysnippet) {
+	encode gzip
+}
+service1.example.com {
+	reverse_proxy service1:5000 {
+		invalid
+	}
+}
+service2.example.com {
+	respond 200 /
+	# Comment
+	reverse_proxy service2:5000 {
+		health_path /health
+	}
+	import mysnippet
+}
+service3.example.com {
+	respond 404 /
+	basicauth /secret {
+		user " a \ b"
+	}
+}
+----------
+service2.example.com {
+	respond 200 /
+	reverse_proxy service2:5000 {
+		health_path /health
+	}
+	encode gzip
+}
+service3.example.com {
+	respond 404 /
+	basicauth /secret {
+		user " a \ b"
+	}
+}

--- a/plugin/generator/testdata/labels/all_special_labels.txt
+++ b/plugin/generator/testdata/labels/all_special_labels.txt
@@ -1,0 +1,13 @@
+caddy                       = service.testdomain.com
+caddy.route                 = /path/*
+caddy.route.0_uri           = strip_prefix /path
+caddy.route.1_rewrite       = * /api{path}
+caddy.route.2_reverse_proxy = {{upstreams https 5000}}
+----------
+service.testdomain.com {
+	route /path/* {
+		uri strip_prefix /path
+		rewrite * /api{path}
+		reverse_proxy https://target:5000
+	}
+}

--- a/plugin/generator/testdata/labels/doesnt_override_existing_proxy.txt
+++ b/plugin/generator/testdata/labels/doesnt_override_existing_proxy.txt
@@ -1,0 +1,8 @@
+caddy                 = testdomain.com
+caddy.reverse_proxy   = something
+caddy.reverse_proxy_1 = /api/* external-api
+----------
+testdomain.com {
+	reverse_proxy /api/* external-api
+	reverse_proxy something
+}

--- a/plugin/generator/testdata/labels/invalid_template.txt
+++ b/plugin/generator/testdata/labels/invalid_template.txt
@@ -1,0 +1,4 @@
+caddy               = service.testdomain.com
+caddy.reverse_proxy = {{invalid}}
+----------
+err: template: :1: function "invalid" not defined

--- a/plugin/generator/testdata/labels/minimum_special_labels.txt
+++ b/plugin/generator/testdata/labels/minimum_special_labels.txt
@@ -1,0 +1,6 @@
+caddy               = service.testdomain.com
+caddy.reverse_proxy = {{upstreams}}
+----------
+service.testdomain.com {
+	reverse_proxy target
+}

--- a/plugin/generator/testdata/labels/multiple_addresses.txt
+++ b/plugin/generator/testdata/labels/multiple_addresses.txt
@@ -1,0 +1,6 @@
+caddy               = a.testdomain.com b.testdomain.com
+caddy.reverse_proxy = {{upstreams}}
+----------
+a.testdomain.com b.testdomain.com {
+	reverse_proxy target
+}

--- a/plugin/generator/testdata/labels/multiple_configs.txt
+++ b/plugin/generator/testdata/labels/multiple_configs.txt
@@ -1,0 +1,21 @@
+caddy_0               = service1.testdomain.com
+caddy_0.reverse_proxy = {{upstreams 5000}}
+caddy_0.rewrite       = * /api{path}
+caddy_0.tls.dns       = route53
+caddy_1               = service2.testdomain.com
+caddy_1.reverse_proxy = {{upstreams 5001}}
+caddy_1.tls.dns       = route53
+----------
+service1.testdomain.com {
+	reverse_proxy target:5000
+	rewrite * /api{path}
+	tls {
+		dns route53
+	}
+}
+service2.testdomain.com {
+	reverse_proxy target:5001
+	tls {
+		dns route53
+	}
+}

--- a/plugin/generator/testdata/labels/reverse_proxy_directives_are_moved_into_route.txt
+++ b/plugin/generator/testdata/labels/reverse_proxy_directives_are_moved_into_route.txt
@@ -1,0 +1,14 @@
+caddy                                   = service.testdomain.com
+caddy.route                             = /path/*
+caddy.route.0_uri                       = strip_prefix /path
+caddy.route.1_reverse_proxy             = {{upstreams}}
+caddy.route.1_reverse_proxy.health_path = /health
+----------
+service.testdomain.com {
+	route /path/* {
+		uri strip_prefix /path
+		reverse_proxy target {
+			health_path /health
+		}
+	}
+}

--- a/plugin/generator/testdata/labels/with_groups.txt
+++ b/plugin/generator/testdata/labels/with_groups.txt
@@ -1,0 +1,8 @@
+caddy               = service.testdomain.com
+caddy.reverse_proxy = {{upstreams https 5000}}
+caddy.rewrite       = * /api{path}
+----------
+service.testdomain.com {
+	reverse_proxy https://target:5000
+	rewrite * /api{path}
+}


### PR DESCRIPTION
As discussed previously, this refactors the tests that use labels or simple strings as inputs into files that contains the input/expected pairs.

I didn't bother touching the tests that have structs as input, I don't have a good way to clean those up while keeping the input/expected together.

This test strategy is something I set up for https://github.com/caddyserver/caddy, it's pretty much the same code for parsing the files. I also pulled the envfile parsing function that's in there as well, with a few modifications like trimming both sides and allowing whitespace around the `=`, because labels aren't as strict as env vars.