### PR TITLE
Refactor Caddyfile representation

### DIFF
--- a/plugin/caddyfile/fromlabels.go
+++ b/plugin/caddyfile/fromlabels.go
@@ -5,56 +5,61 @@ import (
 	"math"
 	"regexp"
 	"strconv"
-	"strings"
 	"text/template"
 )
 
 var whitespaceRegex = regexp.MustCompile("\\s+")
-var labelSegmentRegex = regexp.MustCompile(`^(?:(\d+)_)?(.*?)(?:_(\d+))?$`)
+var labelParserRegex = regexp.MustCompile(`^(?:(.+)\.)?(?:(\d+)_)?([^.]+?)(?:_(\d+))?$`)
 
 // FromLabels converts key value labels into a caddyfile
 func FromLabels(labels map[string]string, templateData interface{}, templateFuncs template.FuncMap) (*Container, error) {
 	container := CreateContainer()
 
+	blocksByPath := map[string]*Block{}
 	for label, value := range labels {
-		block := getOrCreateBlock(container, label)
+		block := getOrCreateBlock(container, label, blocksByPath)
 		argsText, err := processVariables(templateData, templateFuncs, value)
 		if err != nil {
 			return nil, err
 		}
-		block.Args = parseArgs(argsText)
+		block.AddKeys(parseArgs(argsText)...)
 	}
 
 	return container, nil
 }
 
-func getOrCreateBlock(container *Container, path string) *Block {
-	currentContainer := container
-	var block *Block
-	for i, p := range strings.Split(path, ".") {
-		order, name, discriminator := parseLabelSegment(p, i)
-		block = currentContainer.GetFirstMatch(order, name, discriminator)
-		if block == nil {
-			block = CreateBlock(name, discriminator)
-			block.Order = order
-			currentContainer.AddBlock(block)
-		}
-		currentContainer = block.Container
+func getOrCreateBlock(container *Container, path string, blocksByPath map[string]*Block) *Block {
+	if block, blockExists := blocksByPath[path]; blockExists {
+		return block
 	}
+
+	parentPath, order, name := parsePath(path)
+
+	block := CreateBlock()
+	block.Order = order
+
+	if parentPath != "" {
+		parentBlock := getOrCreateBlock(container, parentPath, blocksByPath)
+		block.AddKeys(name)
+		parentBlock.AddBlock(block)
+	} else {
+		container.AddBlock(block)
+	}
+
+	blocksByPath[path] = block
+
 	return block
 }
 
-func parseLabelSegment(text string, index int) (int, string, string) {
-	match := labelSegmentRegex.FindStringSubmatch(text)
+func parsePath(path string) (string, int, string) {
+	match := labelParserRegex.FindStringSubmatch(path)
+	parentPath := match[1]
 	order := math.MaxInt32
-	name := ""
-	if match[1] != "" {
-		order, _ = strconv.Atoi(match[1])
+	if match[2] != "" {
+		order, _ = strconv.Atoi(match[2])
 	}
-	if index > 0 {
-		name = match[2]
-	}
-	return order, name, match[3]
+	name := match[3]
+	return parentPath, order, name
 }
 
 func processVariables(data interface{}, funcs template.FuncMap, content string) (string, error) {

--- a/plugin/caddyfile/fromlabels_test.go
+++ b/plugin/caddyfile/fromlabels_test.go
@@ -47,21 +47,21 @@ func TestLabelsToCaddyfile(t *testing.T) {
 		expectedCaddyfile = winNewlines.ReplaceAllString(expectedCaddyfile, "\n")
 
 		// convert the labels to a Caddyfile
-		caddyfileBlock, err := FromLabels(labels, nil, template.FuncMap{})
+		caddyfileContainer, err := FromLabels(labels, nil, template.FuncMap{})
 
 		// if the result is nil then we expect an empty Caddyfile
-		if caddyfileBlock == nil {
+		if caddyfileContainer == nil {
 			if expectedCaddyfile != "" {
 				t.Errorf("got nil in %s but expected: %s", filename, expectedCaddyfile)
 			}
 			continue
 		}
 
-		// if caddyfileBlock is not nil, we expect no error
+		// if caddyfileContainer is not nil, we expect no error
 		assert.NoError(t, err, "expected no error in %s", filename)
 
 		// compare the actual and expected Caddyfiles
-		actualCaddyfile := strings.TrimSpace(caddyfileBlock.MarshalString())
+		actualCaddyfile := strings.TrimSpace(string(caddyfileContainer.Marshal()))
 		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
 			"comparison failed in %s: \nExpected:\n%s\n\nActual:\n%s\n",
 			filename, expectedCaddyfile, actualCaddyfile)

--- a/plugin/caddyfile/fromlabels_test.go
+++ b/plugin/caddyfile/fromlabels_test.go
@@ -28,43 +28,46 @@ func TestLabelsToCaddyfile(t *testing.T) {
 
 		// read the test file
 		filename := f.Name()
-		data, err := ioutil.ReadFile("./testdata/labels/" + filename)
-		if err != nil {
-			t.Errorf("failed to read %s dir: %s", filename, err)
-		}
 
-		// split the labels (first) and Caddyfile (second) parts
-		parts := strings.Split(string(data), "----------")
-		labelsString, expectedCaddyfile := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
-
-		// parse label key-value pairs
-		labels, err := parseLabelsFromString(labelsString)
-		if err != nil {
-			t.Errorf("failed to parse labels from %s", filename)
-		}
-
-		// replace windows newlines in the json with unix newlines
-		expectedCaddyfile = winNewlines.ReplaceAllString(expectedCaddyfile, "\n")
-
-		// convert the labels to a Caddyfile
-		caddyfileContainer, err := FromLabels(labels, nil, template.FuncMap{})
-
-		// if the result is nil then we expect an empty Caddyfile
-		if caddyfileContainer == nil {
-			if expectedCaddyfile != "" {
-				t.Errorf("got nil in %s but expected: %s", filename, expectedCaddyfile)
+		t.Run(filename, func(t *testing.T) {
+			data, err := ioutil.ReadFile("./testdata/labels/" + filename)
+			if err != nil {
+				t.Errorf("failed to read %s dir: %s", filename, err)
 			}
-			continue
-		}
 
-		// if caddyfileContainer is not nil, we expect no error
-		assert.NoError(t, err, "expected no error in %s", filename)
+			// split the labels (first) and Caddyfile (second) parts
+			parts := strings.Split(string(data), "----------")
+			labelsString, expectedCaddyfile := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 
-		// compare the actual and expected Caddyfiles
-		actualCaddyfile := strings.TrimSpace(string(caddyfileContainer.Marshal()))
-		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
-			"comparison failed in %s: \nExpected:\n%s\n\nActual:\n%s\n",
-			filename, expectedCaddyfile, actualCaddyfile)
+			// parse label key-value pairs
+			labels, err := parseLabelsFromString(labelsString)
+			if err != nil {
+				t.Errorf("failed to parse labels from %s", filename)
+			}
+
+			// replace windows newlines in the json with unix newlines
+			expectedCaddyfile = winNewlines.ReplaceAllString(expectedCaddyfile, "\n")
+
+			// convert the labels to a Caddyfile
+			caddyfileContainer, err := FromLabels(labels, nil, template.FuncMap{})
+
+			// if the result is nil then we expect an empty Caddyfile
+			if caddyfileContainer == nil {
+				if expectedCaddyfile != "" {
+					t.Errorf("got nil in %s but expected: %s", filename, expectedCaddyfile)
+				}
+				return
+			}
+
+			// if caddyfileContainer is not nil, we expect no error
+			assert.NoError(t, err, "expected no error in %s", filename)
+
+			// compare the actual and expected Caddyfiles
+			actualCaddyfile := strings.TrimSpace(string(caddyfileContainer.Marshal()))
+			assert.Equal(t, expectedCaddyfile, actualCaddyfile,
+				"comparison failed in %s: \nExpected:\n%s\n\nActual:\n%s\n",
+				filename, expectedCaddyfile, actualCaddyfile)
+		})
 	}
 }
 

--- a/plugin/caddyfile/marshal.go
+++ b/plugin/caddyfile/marshal.go
@@ -10,35 +10,30 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/standard" // plug standard HTTP modules
 )
 
-// Marshal block into caddyfile bytes
-func (block *Block) Marshal() []byte {
+// Marshal container into caddyfile bytes
+func (container *Container) Marshal() []byte {
 	buffer := &bytes.Buffer{}
-	block.Write(buffer, 0)
+	container.Write(buffer, 0)
 	return buffer.Bytes()
 }
 
-// MarshalString block into caddyfile string
-func (block *Block) MarshalString() string {
-	return string(block.Marshal())
-}
-
-// Write all directives to a buffer
-func (block *Block) Write(buffer *bytes.Buffer, level int) {
-	block.sort(level)
-	for _, subdirective := range block.Children {
-		subdirective.Write(buffer, level)
+// Write all blocks to a buffer
+func (container *Container) Write(buffer *bytes.Buffer, level int) {
+	container.sort(level)
+	for _, block := range container.Children {
+		block.Write(buffer, level)
 	}
 }
 
-// Write directive to a buffer
-func (directive *Directive) Write(buffer *bytes.Buffer, level int) {
+// Write block to a buffer
+func (block *Block) Write(buffer *bytes.Buffer, level int) {
 	buffer.WriteString(strings.Repeat("\t", level))
 	needsWhitespace := false
-	if level > 0 && directive.Name != "" {
-		buffer.WriteString(directive.Name)
+	if level > 0 && block.Name != "" {
+		buffer.WriteString(block.Name)
 		needsWhitespace = true
 	}
-	for _, arg := range directive.Args {
+	for _, arg := range block.Args {
 		if needsWhitespace {
 			buffer.WriteString(" ")
 		}
@@ -53,19 +48,19 @@ func (directive *Directive) Write(buffer *bytes.Buffer, level int) {
 
 		needsWhitespace = true
 	}
-	if len(directive.Children) > 0 {
+	if len(block.Children) > 0 {
 		if needsWhitespace {
 			buffer.WriteString(" ")
 		}
 		buffer.WriteString("{\n")
-		directive.Block.Write(buffer, level+1)
+		block.Container.Write(buffer, level+1)
 		buffer.WriteString(strings.Repeat("\t", level) + "}")
 	}
 	buffer.WriteString("\n")
 }
 
-func (block *Block) sort(level int) {
-	items := block.Children
+func (container *Container) sort(level int) {
+	items := container.Children
 	sort.SliceStable(items, func(i, j int) bool {
 		if level == 0 && items[i].IsGlobalBlock() && !items[j].IsGlobalBlock() {
 			return true
@@ -84,54 +79,54 @@ func (block *Block) sort(level int) {
 }
 
 // Unmarshal a Block fom caddyfile content
-func Unmarshal(caddyfileContent []byte) (*Block, error) {
+func Unmarshal(caddyfileContent []byte) (*Container, error) {
 	serverBlocks, err := caddyfile.Parse("", caddyfileContent)
 	if err != nil {
 		return nil, err
 	}
 
-	block := CreateBlock()
+	container := CreateContainer()
 	for index, serverBlock := range serverBlocks {
-		block.AddDirective(unmarshalServerBlock(&serverBlock, index))
+		container.AddBlock(unmarshalServerBlock(&serverBlock, index))
 	}
-	return block, nil
+	return container, nil
 }
 
-func unmarshalServerBlock(serverBlock *caddyfile.ServerBlock, index int) *Directive {
-	stack := []*Directive{}
+func unmarshalServerBlock(serverBlock *caddyfile.ServerBlock, index int) *Block {
+	stack := []*Block{}
 
-	directive := CreateDirective("caddy", strconv.Itoa(index))
-	directive.Order = index
-	directive.AddArgs(serverBlock.Keys...)
-	stack = append(stack, directive)
+	block := CreateBlock("", strconv.Itoa(index))
+	block.Order = index
+	block.AddArgs(serverBlock.Keys...)
+	stack = append(stack, block)
 
 	for _, segment := range serverBlock.Segments {
-		newDirective := true
+		isNewBlock := true
 		tokenLine := -1
-		var subDirective *Directive
+		var subBlock *Block
 
 		for _, token := range segment {
 			if token.Line != tokenLine {
 				if tokenLine != -1 {
-					newDirective = true
+					isNewBlock = true
 				}
 				tokenLine = token.Line
 			}
 			if token.Text == "}" {
 				stack = stack[:len(stack)-1]
 			} else if token.Text == "{" {
-				stack = append(stack, subDirective)
-			} else if newDirective {
-				parentDirective := stack[len(stack)-1]
-				subDirective = CreateDirective(token.Text, "")
-				subDirective.Order = len(parentDirective.Children)
-				parentDirective.AddDirective(subDirective)
-				newDirective = false
+				stack = append(stack, subBlock)
+			} else if isNewBlock {
+				parentBlock := stack[len(stack)-1]
+				subBlock = CreateBlock(token.Text, "")
+				subBlock.Order = len(parentBlock.Children)
+				parentBlock.AddBlock(subBlock)
+				isNewBlock = false
 			} else {
-				subDirective.AddArgs(token.Text)
+				subBlock.AddArgs(token.Text)
 			}
 		}
 	}
 
-	return directive
+	return block
 }

--- a/plugin/caddyfile/marshal_test.go
+++ b/plugin/caddyfile/marshal_test.go
@@ -29,25 +29,28 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 		// read the test file
 		filename := f.Name()
-		data, err := ioutil.ReadFile(folder + "/" + filename)
-		if err != nil {
-			t.Errorf("failed to read %s dir: %s", filename, err)
-		}
 
-		// replace windows newlines in the json with unix newlines
-		content := winNewlines.ReplaceAllString(string(data), "\n")
+		t.Run(filename, func(t *testing.T) {
+			data, err := ioutil.ReadFile(folder + "/" + filename)
+			if err != nil {
+				t.Errorf("failed to read %s dir: %s", filename, err)
+			}
 
-		// split two Caddyfile parts
-		parts := strings.Split(content, "----------\n")
-		beforeCaddyfile, expectedCaddyfile := parts[0], parts[1]
+			// replace windows newlines in the json with unix newlines
+			content := winNewlines.ReplaceAllString(string(data), "\n")
 
-		container, _ := Unmarshal([]byte(beforeCaddyfile))
-		result := string(container.Marshal())
+			// split two Caddyfile parts
+			parts := strings.Split(content, "----------\n")
+			beforeCaddyfile, expectedCaddyfile := parts[0], parts[1]
 
-		actualCaddyfile := string(result)
+			container, _ := Unmarshal([]byte(beforeCaddyfile))
+			result := string(container.Marshal())
 
-		// compare the actual and expected Caddyfiles
-		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
-			"failed to process in %s", filename)
+			actualCaddyfile := string(result)
+
+			// compare the actual and expected Caddyfiles
+			assert.Equal(t, expectedCaddyfile, actualCaddyfile,
+				"failed to process in %s", filename)
+		})
 	}
 }

--- a/plugin/caddyfile/marshal_test.go
+++ b/plugin/caddyfile/marshal_test.go
@@ -41,8 +41,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 		parts := strings.Split(content, "----------\n")
 		beforeCaddyfile, expectedCaddyfile := parts[0], parts[1]
 
-		block, _ := Unmarshal([]byte(beforeCaddyfile))
-		result := block.MarshalString()
+		container, _ := Unmarshal([]byte(beforeCaddyfile))
+		result := string(container.Marshal())
 
 		actualCaddyfile := string(result)
 

--- a/plugin/caddyfile/merger.go
+++ b/plugin/caddyfile/merger.go
@@ -2,50 +2,50 @@ package caddyfile
 
 import "strings"
 
-// Merge a second caddyfile block into the current block
-func (blockA *Block) Merge(blockB *Block) {
+// Merge a second caddyfile container into the current container
+func (containerA *Container) Merge(containerB *Container) {
 OuterLoop:
-	for _, directiveB := range blockB.Children {
-		name := directiveB.Name
-		for _, directiveA := range blockA.GetAllByName(name) {
-			if name == "reverse_proxy" && getMatcher(directiveA) == getMatcher(directiveB) {
-				mergeReverseProxy(directiveA, directiveB)
+	for _, blockB := range containerB.Children {
+		name := blockB.Name
+		for _, blockA := range containerA.GetAllByName(name) {
+			if name == "reverse_proxy" && getMatcher(blockA) == getMatcher(blockB) {
+				mergeReverseProxy(blockA, blockB)
 				continue OuterLoop
-			} else if directiveArgsAreEqual(directiveA, directiveB) {
-				directiveA.Block.Merge(directiveB.Block)
+			} else if blocksAreEqual(blockA, blockB) {
+				blockA.Container.Merge(blockB.Container)
 				continue OuterLoop
 			}
 		}
-		blockA.AddDirective(directiveB)
+		containerA.AddBlock(blockB)
 	}
 }
 
-func mergeReverseProxy(directiveA *Directive, directiveB *Directive) {
-	for index, arg := range directiveB.Args {
+func mergeReverseProxy(blockA *Block, blockB *Block) {
+	for index, arg := range blockB.Args {
 		if index > 0 || !isMatcher(arg) {
-			directiveA.AddArgs(arg)
+			blockA.AddArgs(arg)
 		}
 	}
-	directiveA.Block.Merge(directiveB.Block)
+	blockA.Container.Merge(blockB.Container)
 }
 
-func getMatcher(directive *Directive) string {
-	if len(directive.Args) == 0 || !isMatcher(directive.Args[0]) {
+func getMatcher(block *Block) string {
+	if len(block.Args) == 0 || !isMatcher(block.Args[0]) {
 		return "*"
 	}
-	return directive.Args[0]
+	return block.Args[0]
 }
 
 func isMatcher(value string) bool {
 	return value == "*" || strings.HasPrefix(value, "/") || strings.HasPrefix(value, "@")
 }
 
-func directiveArgsAreEqual(directiveA *Directive, directiveB *Directive) bool {
-	if len(directiveA.Args) != len(directiveB.Args) {
+func blocksAreEqual(blockA *Block, blockB *Block) bool {
+	if len(blockA.Args) != len(blockB.Args) {
 		return false
 	}
-	for i := 0; i < len(directiveA.Args); i++ {
-		if directiveA.Args[i] != directiveB.Args[i] {
+	for i := 0; i < len(blockA.Args); i++ {
+		if blockA.Args[i] != blockB.Args[i] {
 			return false
 		}
 	}

--- a/plugin/caddyfile/processor.go
+++ b/plugin/caddyfile/processor.go
@@ -3,17 +3,15 @@ package caddyfile
 import (
 	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 )
 
 // Process caddyfile and removes wrong server blocks
 func Process(caddyfileContent []byte) ([]byte, []byte) {
 	logsBuffer := bytes.Buffer{}
 
-	serverBlocks, err := caddyfile.Parse("", caddyfileContent)
+	container, err := Unmarshal(caddyfileContent)
 
 	if err != nil {
 		logsBuffer.WriteString(fmt.Sprintf("[ERROR] Error parsing caddyfile: %s\n", err.Error()))
@@ -21,71 +19,20 @@ func Process(caddyfileContent []byte) ([]byte, []byte) {
 
 	var newCaddyfileBuffer bytes.Buffer
 
-	for _, serverBlock := range serverBlocks {
-		serverBlockContent := serializeServerBlock(&serverBlock)
+	for _, block := range container.Children {
+		newContainer := CreateContainer()
+		newContainer.AddBlock(block)
+
+		blockCaddyfileContent := newContainer.Marshal()
 
 		adapter := caddyconfig.GetAdapter("caddyfile")
 
-		_, _, err := adapter.Adapt(serverBlockContent, nil)
+		_, _, err := adapter.Adapt(blockCaddyfileContent, nil)
 		if err == nil {
-			newCaddyfileBuffer.Write(serverBlockContent)
+			newCaddyfileBuffer.Write(blockCaddyfileContent)
 		} else {
-			logsBuffer.WriteString(fmt.Sprintf("[ERROR]  Removing invalid server block: %s\n%s\n", err.Error(), serverBlockContent))
+			logsBuffer.WriteString(fmt.Sprintf("[ERROR]  Removing invalid block: %s\n%s\n", err.Error(), blockCaddyfileContent))
 		}
 	}
 	return newCaddyfileBuffer.Bytes(), logsBuffer.Bytes()
-}
-
-func serializeServerBlock(serverBlock *caddyfile.ServerBlock) []byte {
-	var writer bytes.Buffer
-	writeServerBlock(&writer, serverBlock)
-	return writer.Bytes()
-}
-
-func writeServerBlock(writer *bytes.Buffer, serverBlock *caddyfile.ServerBlock) {
-	key := strings.Join(serverBlock.Keys, " ")
-	if key != "" {
-		writer.WriteString(key)
-		writer.WriteString(" ")
-	}
-	writer.WriteString("{\n")
-
-	for _, segment := range serverBlock.Segments {
-		indent := 1
-		newLine := true
-		tokenLine := -1
-		for _, token := range segment {
-			if token.Text == "}" {
-				indent--
-			}
-			if token.Line != tokenLine {
-				if tokenLine != -1 {
-					writer.WriteString("\n")
-					newLine = true
-				}
-				tokenLine = token.Line
-			}
-			if newLine {
-				writer.WriteString(strings.Repeat("\t", indent))
-				newLine = false
-			} else {
-				writer.WriteString(" ")
-			}
-
-			if strings.ContainsAny(token.Text, ` "'`) {
-				writer.WriteString("\"")
-				escapedToken := strings.ReplaceAll(token.Text, "\"", "\\\"")
-				writer.WriteString(escapedToken)
-				writer.WriteString("\"")
-			} else {
-				writer.WriteString(token.Text)
-			}
-
-			if token.Text == "{" {
-				indent++
-			}
-		}
-		writer.WriteString("\n")
-	}
-	writer.WriteString("}\n")
 }

--- a/plugin/caddyfile/processor_test.go
+++ b/plugin/caddyfile/processor_test.go
@@ -28,26 +28,29 @@ func TestProcessCaddyfile(t *testing.T) {
 
 		// read the test file
 		filename := f.Name()
-		data, err := ioutil.ReadFile("./testdata/process/" + filename)
-		if err != nil {
-			t.Errorf("failed to read %s dir: %s", filename, err)
-		}
 
-		// replace windows newlines in the json with unix newlines
-		content := winNewlines.ReplaceAllString(string(data), "\n")
+		t.Run(filename, func(t *testing.T) {
+			data, err := ioutil.ReadFile("./testdata/process/" + filename)
+			if err != nil {
+				t.Errorf("failed to read %s dir: %s", filename, err)
+			}
 
-		// split two Caddyfile parts
-		parts := strings.Split(content, "----------\n")
-		beforeCaddyfile, expectedCaddyfile := parts[0], parts[1]
+			// replace windows newlines in the json with unix newlines
+			content := winNewlines.ReplaceAllString(string(data), "\n")
 
-		// process the Caddyfile
-		result, _ := Process([]byte(beforeCaddyfile))
+			// split two Caddyfile parts
+			parts := strings.Split(content, "----------\n")
+			beforeCaddyfile, expectedCaddyfile := parts[0], parts[1]
 
-		actualCaddyfile := string(result)
+			// process the Caddyfile
+			result, _ := Process([]byte(beforeCaddyfile))
 
-		// compare the actual and expected Caddyfiles
-		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
-			"failed to process in %s, \nExpected:\n%s\nActual:\n%s",
-			filename, expectedCaddyfile, actualCaddyfile)
+			actualCaddyfile := string(result)
+
+			// compare the actual and expected Caddyfiles
+			assert.Equal(t, expectedCaddyfile, actualCaddyfile,
+				"failed to process in %s, \nExpected:\n%s\nActual:\n%s",
+				filename, expectedCaddyfile, actualCaddyfile)
+		})
 	}
 }

--- a/plugin/generator/containers.go
+++ b/plugin/generator/containers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lucaslorentz/caddy-docker-proxy/plugin/v2/caddyfile"
 )
 
-func (g *CaddyfileGenerator) getContainerCaddyfile(container *types.Container, logsBuffer *bytes.Buffer) (*caddyfile.Block, error) {
+func (g *CaddyfileGenerator) getContainerCaddyfile(container *types.Container, logsBuffer *bytes.Buffer) (*caddyfile.Container, error) {
 	caddyLabels := g.filterLabels(container.Labels)
 
 	return labelsToCaddyfile(caddyLabels, container, func() ([]string, error) {

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -67,7 +67,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile() ([]byte, string, []string) {
 		g.swarmIsAvailableTime = time.Now()
 	}
 
-	caddyfileBlock := caddyfile.CreateBlock()
+	caddyfileBlock := caddyfile.CreateContainer()
 	controlledServers := []string{}
 
 	// Add caddyfile from path
@@ -174,10 +174,10 @@ func (g *CaddyfileGenerator) GenerateCaddyfile() ([]byte, string, []string) {
 	}
 
 	// Write global blocks first
-	for _, directive := range caddyfileBlock.Children {
-		if directive.IsGlobalBlock() {
-			directive.Write(&caddyfileBuffer, 0)
-			caddyfileBlock.Remove(directive)
+	for _, block := range caddyfileBlock.Children {
+		if block.IsGlobalBlock() {
+			block.Write(&caddyfileBuffer, 0)
+			caddyfileBlock.Remove(block)
 		}
 	}
 

--- a/plugin/generator/labels.go
+++ b/plugin/generator/labels.go
@@ -10,7 +10,7 @@ import (
 
 type targetsProvider func() ([]string, error)
 
-func labelsToCaddyfile(labels map[string]string, templateData interface{}, getTargets targetsProvider) (*caddyfile.Block, error) {
+func labelsToCaddyfile(labels map[string]string, templateData interface{}, getTargets targetsProvider) (*caddyfile.Container, error) {
 	funcMap := template.FuncMap{
 		"upstreams": func(options ...interface{}) (string, error) {
 			targets, err := getTargets()

--- a/plugin/generator/labels_test.go
+++ b/plugin/generator/labels_test.go
@@ -65,7 +65,7 @@ func TestLabelsToCaddyfile(t *testing.T) {
 		assert.NoError(t, err, "expected no error in %s", filename)
 
 		// compare the actual and expected Caddyfiles
-		actualCaddyfile := strings.TrimSpace(caddyfileBlock.MarshalString())
+		actualCaddyfile := strings.TrimSpace(string(caddyfileBlock.Marshal()))
 		assert.Equal(t, expectedCaddyfile, actualCaddyfile,
 			"comparison failed in %s: \nExpected:\n%s\n\nActual:\n%s\n",
 			filename, expectedCaddyfile, actualCaddyfile)

--- a/plugin/generator/services.go
+++ b/plugin/generator/services.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lucaslorentz/caddy-docker-proxy/plugin/v2/caddyfile"
 )
 
-func (g *CaddyfileGenerator) getServiceCaddyfile(service *swarm.Service, logsBuffer *bytes.Buffer) (*caddyfile.Block, error) {
+func (g *CaddyfileGenerator) getServiceCaddyfile(service *swarm.Service, logsBuffer *bytes.Buffer) (*caddyfile.Container, error) {
 	caddyLabels := g.filterLabels(service.Spec.Labels)
 
 	return labelsToCaddyfile(caddyLabels, service, func() ([]string, error) {


### PR DESCRIPTION
Refactor to make Caddyfile representation more clear.
Align Caddyfile representation with official Caddy terminology.

This is only refactorings, no intended behavior changes.