### PR TITLE
Add Dockerfile to be called from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,13 @@
-FROM alpine:3.11 as alpine
-RUN apk add -U --no-cache ca-certificates
+ARG CADDY_VERSION=2.1.1
 
-# Image starts here
-FROM scratch
-LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
+FROM caddy:${CADDY_VERSION}-builder AS builder
 
-EXPOSE 80 443 2019
-ENV XDG_CONFIG_HOME /config
-ENV XDG_DATA_HOME /data
+ARG PLUGINS=
 
-WORKDIR /
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+RUN caddy-builder \
+    github.com/lucaslorentz/caddy-docker-proxy/plugin/v2 \
+    ${PLUGINS}
 
-COPY artifacts/binaries/linux/amd64/caddy /bin/
+FROM caddy:${CADDY_VERSION}
 
-ENTRYPOINT ["/bin/caddy"]
-
-CMD ["docker-proxy"]
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/Dockerfile-scratch
+++ b/Dockerfile-scratch
@@ -1,0 +1,19 @@
+FROM alpine:3.11 as alpine
+RUN apk add -U --no-cache ca-certificates
+
+# Image starts here
+FROM scratch
+LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
+
+EXPOSE 80 443 2019
+ENV XDG_CONFIG_HOME /config
+ENV XDG_DATA_HOME /data
+
+WORKDIR /
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY artifacts/binaries/linux/amd64/caddy /bin/
+
+ENTRYPOINT ["/bin/caddy"]
+
+CMD ["docker-proxy"]

--- a/build-images-linux.sh
+++ b/build-images-linux.sh
@@ -3,7 +3,7 @@
 set -e
 
 chmod +x artifacts/binaries/linux/amd64/caddy
-docker build -t lucaslorentz/caddy-docker-proxy:ci -f Dockerfile .
+docker build -t lucaslorentz/caddy-docker-proxy:ci -f Dockerfile-scratch .
 docker build -t lucaslorentz/caddy-docker-proxy:ci-alpine -f Dockerfile-alpine .
 
 chmod +x artifacts/binaries/linux/arm32v6/caddy


### PR DESCRIPTION
How to use it before merging this PR:
```
docker build --build-arg "PLUGINS=github.com/caddyserver/nginx-adapter github.com/hairyhenderson/caddyprom" -t your-tag-name https://github.com/lucaslorentz/caddy-docker-proxy.git#builder
```

After merging this PR, we can drop the `#builder` (branch).

@flaviostutz
What do you think about this as as fix for https://github.com/lucaslorentz/caddy-docker-proxy/issues/175?

PS: I still need to udpate the README file.