### PR TITLE
[RFC] virtual.port and virtual.host work, including virtual.port_1 -> caddy.route_1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-*
+#*
 !artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 artifacts
 vendor
 debug.test
+.env

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,10 @@
+{
+    admin 0.0.0.0:2019
+    email sven@{env.STACKDOMAIN}
+}
+
+(user_headers) {
+    header -X-Forwarded-User
+    request_header X-Forwarded-User {http.auth.user.id}
+}
+

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,31 @@
+
+# docker build --target xcaddy --tag xcaddy .
+FROM golang:1.14 as xcaddy
+
+# get xcaddy
+RUN go get -u github.com/caddyserver/xcaddy/cmd/xcaddy
+
+# docker build -f Dockerfile.dev --target build --tag build .
+FROM xcaddy as build
+
+WORKDIR /src/
+COPY . /src/
+
+# https://caddy.community/t/how-to-use-dns-provider-modules-in-caddy-2/8148
+RUN xcaddy build \
+    --with github.com/caddy-dns/gandi \
+    --with github.com/lucaslorentz/caddy-docker-proxy/plugin/v2=/src/plugin/
+
+RUN ls -la
+
+# docker build -f Dockerfile.dev --target cdp --tag cdp .
+FROM caddy as cdp
+COPY --from=build /src/caddy /usr/bin/caddy
+
+ENV GANDIV5_API_KEY=
+
+#oh :( want it to use the autosave file if its there - unless the /config.caddy.json is newer
+CMD [ "caddy", "docker-proxy" ]
+
+
+# docker run --rm -it -p 443:443 -p 80:80 -p 2019:2019 -e GANDIV5_API_KEY -v /run/docker.sock:/run/docker.sock -v $(pwd)/data:/data cdp 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+build:
+	docker build -f Dockerfile.dev --target build --tag build .
+	docker build -f Dockerfile.dev --target cdp --tag cdp .
+
+run:
+	docker-compose up
+
+list:
+	docker run --rm -it cdp caddy list-modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,16 +82,16 @@ services:
           cpus: "0.1"
           memory: 200M
 
-  # Proxy to service
-  whoami0:
+  # This should become the built in "404 / maintainence page"
+  # need a way to tell cirri-infra not to instanciate this, because we have one...
+  maintainence:
     image: jwilder/whoami
     networks:
       - cirri_proxy
     labels:
-      # this one can't be a simple (virtual.port) caddy.route, as its the "default fallback"
-      #virtual.port: 8000
-      caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
-      caddy.reverse_proxy: "{{upstreams 8000}}"
+      # this one can't be a simple (virtual.port) caddy.route, so we use "not"
+      caddy.route: "not"
+      virtual.port: 8000
       # need this once - so TODO: move to a caddy-admin-view service?
       caddy.import_0: dns.${STACKDOMAIN:-loc.alho.st}
       caddy.import_1: user_headers
@@ -168,16 +168,22 @@ services:
 
       caddy.route.import: admin
 
+  # this is the route an (at root domain dashboard would use)
   default:
     image: jwilder/whoami
     networks:
       - cirri_proxy
     labels:
       virtual.port: 8000
+
+      # in the absense of a virtual.host, or other caddy route specifier, we kill all other routes
+      # TODO: this is a dangerous default, so CHANGEME
+      virtual.host: "${STACKDOMAIN:-loc.alho.st}"
+
       # I't be nice if, in the absense of a virtual.host, it used the service/container name
       # TODO: this has a leading / that needs removeal
       # TODO: would be nice if we could have the compose services name ala swarm...
-      virtual.host: "{{index .Names 0}}.${STACKDOMAIN:-loc.alho.st}"
+      #virtual.host: "{{index .Names 0}}.${STACKDOMAIN:-loc.alho.st}"
 
   disconnected:
     image: jwilder/whoami

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 80:80
       - 443:443
     environment:
-      - GANDIV5_API_KEY=
+      - GANDIV5_API_KEY=${GANDIV5_API_KEY}
       - STACKDOMAIN=${STACKDOMAIN:-loc.alho.st} # MUST BE SET (there's no way to set a default that's used in other compose files.)
 
       - CADDY_DOCKER_CADDYFILE_PATH=/Caddyfile
@@ -167,6 +167,28 @@ services:
       virtual.host: "auth.${STACKDOMAIN:-loc.alho.st}"
 
       caddy.route.import: admin
+
+  default:
+    image: jwilder/whoami
+    networks:
+      - cirri_proxy
+    labels:
+      virtual.port: 8000
+      # I't be nice if, in the absense of a virtual.host, it used the service/container name
+      # TODO: this has a leading / that needs removeal
+      # TODO: would be nice if we could have the compose services name ala swarm...
+      virtual.host: "{{index .Names 0}}.${STACKDOMAIN:-loc.alho.st}"
+
+  disconnected:
+    image: jwilder/whoami
+    # networks:
+    # NOT connected to caddy
+    #   - cirri_proxy
+    # this creates a virtual host but caddy then gives a 502
+    # MAYBE cdp shouldn't make the entrys?
+    labels:
+      virtual.port: 8000
+      virtual.host: "disconnected.${STACKDOMAIN:-loc.alho.st}"
 
 networks:
   cirri_proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,178 @@
+version: "3.7"
+
+services:
+  caddy:
+    #image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    image: cdp
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - GANDIV5_API_KEY=
+      - STACKDOMAIN=${STACKDOMAIN:-loc.alho.st} # MUST BE SET (there's no way to set a default that's used in other compose files.)
+
+      - CADDY_DOCKER_CADDYFILE_PATH=/Caddyfile
+    #   - CADDY_CONTROLLER_NETWORK=<string>
+    #   - CADDY_INGRESS_NETWORKS=<string>
+    #   - CADDY_DOCKER_LABEL_PREFIX=<string>
+    #   - CADDY_DOCKER_MODE=<string>
+    #   - CADDY_DOCKER_POLLING_INTERVAL=<duration>
+    #   - CADDY_DOCKER_PROCESS_CADDYFILE=<bool>
+    #   - CADDY_DOCKER_PROXY_SERVICE_TASKS=<bool>
+    networks:
+      - cirri_proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # this volume is needed to keep the certificates
+      # otherwise, new ones will be re-issued upon restart
+      - caddy_data:/data
+      - ./Caddyfile:/Caddyfile
+    labels: # Global options for non-swarm container
+      # TODO: move most of these into the CADDY_DOCKER_CADDYFILE_PATH=/Caddyfile
+
+      # Set to see lots more log info
+      caddy.debug: "true"
+
+      caddy_1: "(dns.${STACKDOMAIN:-loc.alho.st})"
+      caddy_1.tls.dns: "gandi {env.GANDIV5_API_KEY}"
+
+      # Darn, these go tmpl values are evaluated before the import
+      #caddy_1.header_0: 'image "{{.Image}}"'
+      #caddy_1.header: 'container "{args.0}"'
+      #caddy_1.header: 'service "{{.Spec.Name}}"'
+      # won't work, as the `caddy:` label needs to gointo the pre-caddyfile map-tree
+      #caddy_1: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
+      #caddy_1.tls.ca: https://acme-staging-v02.api.letsencrypt.org/directory
+
+      # caddy_3: "(user_headers)"
+      # # add username and role to the request header
+      # caddy_3.request_header_0: 'X-Forwarded-User "{http.auth.user.id}"'
+      # caddy_3.header_0: "-X-Forwarded-User"
+
+      # admin user gives us admin role
+      caddy_4: "(admin)"
+      # use: docker run --rm -it cdp caddy hash-password
+      caddy_4.basicauth.admin: "JDJhJDEwJFFkUTF3cmNaNzFLUmJBL3dIZnVjNnV5dC9WYlBUOEQ5T1FXdTVMLmc2Vy5MZWZvd2RJR2Nh"
+      caddy_4.request_header_1: 'role "admin"'
+      caddy_4.header_1: "-role"
+      caddy_4.import: user_headers
+
+      # admin users gives us users role
+      caddy_5: "(users)"
+      # use: docker run --rm -it cdp caddy hash-password
+      caddy_5.basicauth.first: "JDJhJDEwJFFkUTF3cmNaNzFLUmJBL3dIZnVjNnV5dC9WYlBUOEQ5T1FXdTVMLmc2Vy5MZWZvd2RJR2Nh"
+      caddy_5.basicauth.second: "JDJhJDEwJFFkUTF3cmNaNzFLUmJBL3dIZnVjNnV5dC9WYlBUOEQ5T1FXdTVMLmc2Vy5MZWZvd2RJR2Nh"
+      caddy_5.basicauth.third: "JDJhJDEwJFFkUTF3cmNaNzFLUmJBL3dIZnVjNnV5dC9WYlBUOEQ5T1FXdTVMLmc2Vy5MZWZvd2RJR2Nh"
+      caddy_5.request_header_1: 'role "users"'
+      caddy_5.header_1: "-role"
+      caddy_5.import: user_headers
+
+    deploy:
+      labels: # Global options for swarm service
+        caddy.email: you@${STACKDOMAIN:-loc.alho.st}
+        caddy.admin: "0.0.0.0:2019"
+      placement:
+        constraints:
+          - node.role == manager
+      replicas: 1
+      restart_policy:
+        condition: any
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: 200M
+
+  # Proxy to service
+  whoami0:
+    image: jwilder/whoami
+    networks:
+      - cirri_proxy
+    labels:
+      # this one can't be a simple (virtual.port) caddy.route, as its the "default fallback"
+      #virtual.port: 8000
+      caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
+      caddy.reverse_proxy: "{{upstreams 8000}}"
+      # need this once - so TODO: move to a caddy-admin-view service?
+      caddy.import_0: dns.${STACKDOMAIN:-loc.alho.st}
+      caddy.import_1: user_headers
+
+  # Proxy to service that you want to expose to the outside world
+  whoami1:
+    image: jwilder/whoami
+    networks:
+      - cirri_proxy
+    labels:
+      #caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route.reverse_proxy: "{{upstreams 8000}}"
+      virtual.port: 8000
+
+      #caddy.@sub.host: "sub.${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route: "@sub"
+      virtual.host: "sub.${STACKDOMAIN:-loc.alho.st}"
+
+  # Proxy to container
+  whoami2:
+    image: jwilder/whoami
+    networks:
+      - cirri_proxy
+    labels:
+      #caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route.reverse_proxy: "{{upstreams 8000}}"
+      virtual.port: 8000
+
+      #caddy.@whoami2.host: "short.${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route: "@whoami2"
+      virtual.host: "short.${STACKDOMAIN:-loc.alho.st}"
+
+  # Proxy with matches and 2 routes
+  echo_0:
+    image: brndnmtthws/nginx-echo-headers
+    networks:
+      - cirri_proxy
+    labels:
+      #caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
+      #caddy.@echo.host: "echo.${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route_1: "@echo"
+      virtual.host_1: "echo.${STACKDOMAIN:-loc.alho.st}"
+      caddy.route_1.import: users
+      #caddy.route_1.reverse_proxy: "{{upstreams 8080}}"
+      virtual.port_1: 8080
+
+      caddy.@match.path: "/sourcepath /sourcepath/*"
+      caddy.route: "@match"
+      # OH :() order matters - the import users needs to come before the reverse_proxy
+      caddy.route.0_import: users
+      caddy.route.1_uri: "strip_prefix /sourcepath"
+      caddy.route.2_rewrite: "* /targetpath{path}"
+      caddy.route.3_reverse_proxy: "{{upstreams 8080}}"
+
+      # examples of a container messing with the global (admin) snippet
+      caddy_3: "(admin)"
+      caddy_3.header_1: 'Echo-Loaded "true"'
+      caddy_2: "(admin)"
+      # this needs to be converted to caddy {args.0} for late binding
+      caddy_2.header_1: 'Image-Name "{{.Image}}"'
+
+  auth_0:
+    image: brndnmtthws/nginx-echo-headers
+    networks:
+      - cirri_proxy
+    labels:
+      #caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route.reverse_proxy: "{{upstreams 8080}}"
+      virtual.port: 8080
+
+      #caddy.@auth0.host: "auth.${STACKDOMAIN:-loc.alho.st}"
+      #caddy.route: "@auth0"
+      virtual.host: "auth.${STACKDOMAIN:-loc.alho.st}"
+
+      caddy.route.import: admin
+
+networks:
+  cirri_proxy:
+    name: cirri_proxy
+    #driver: overlay
+
+volumes:
+  caddy_data:
+    name: image_caddy_data

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -298,7 +298,13 @@ func (g *CaddyfileGenerator) filterLabels(labels map[string]string) map[string]s
 			if tag := strings.TrimPrefix(label, "virtual.host_"); tag != label {
 				route = fmt.Sprintf("caddy.route_%s", tag)
 			}
+			// TODO: need to replace {},[]etc too
 			host := strings.ReplaceAll(fmt.Sprintf("@%s", value), ".", "_")
+			host = strings.ReplaceAll(host, "{", "")
+			host = strings.ReplaceAll(host, "}", "")
+			host = strings.ReplaceAll(host, "[", "")
+			host = strings.ReplaceAll(host, "]", "")
+			host = strings.ReplaceAll(host, " ", "")
 			filteredLabels[route] = host
 			log.Printf("[INFO]: out macro %s: %s\n", route, filteredLabels[route])
 


### PR DESCRIPTION
I thought I'd better play with https://github.com/lucaslorentz/caddy-docker-proxy/issues/181#issuecomment-674622078 so I hacked up a bad version without any attempt to templatize or make it configurable.

it takes the caddy specific labels

```
  whoami2:
    image: jwilder/whoami
    networks:
      - cirri_proxy
    labels:
      caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
      caddy.route.reverse_proxy: "{{upstreams 8000}}"
      caddy.@whoami2.host: "short.${STACKDOMAIN:-loc.alho.st}"
      caddy.route: "@whoami2"
```

and converts it into a user/container centric "fact" label

```
  whoami2:
    image: jwilder/whoami
    networks:
      - cirri_proxy
    labels:
      virtual.port: 8000
      virtual.host: "short.${STACKDOMAIN:-loc.alho.st}"
```

without making it difficult to drop to the more expressive caddyfile syntax.

for example, mixing the 2 label types is possible (`caddy.route_1.import`)

```
  # Proxy with matches and 2 routes
  echo_0:
    image: brndnmtthws/nginx-echo-headers
    networks:
      - cirri_proxy
    labels:
      # 2 different host paths to the same container backend
      virtual.port: 8080
      virtual.host: "short.${STACKDOMAIN:-loc.alho.st}"

      # the second also requireing basic auth
      #caddy: "*.${STACKDOMAIN:-loc.alho.st} ${STACKDOMAIN:-loc.alho.st}"
      #caddy.@echo.host: "echo.${STACKDOMAIN:-loc.alho.st}"
      #caddy.route_1: "@echo"
      virtual.host_1: "echo.${STACKDOMAIN:-loc.alho.st}"
      caddy.route_1.import: users
      #caddy.route_1.reverse_proxy: "{{upstreams 8080}}"
      virtual.port_1: 8080
```

Obviously this implementation isn't useful for more than testing the idea - @lucaslorentz what do you think? is a less hacky version something you'd be interested in? and do you think it should begin as user defined macro's with arguments, or would it already be useful to mirror https://github.com/wemake-services/caddy-gen/ ?

