### PR TITLE
Improved container id extraction from cgroups logic

### DIFF
--- a/plugin/docker/utils.go
+++ b/plugin/docker/utils.go
@@ -35,9 +35,14 @@ func (wrapper *dockerUtils) GetCurrentContainerID() (string, error) {
 		return "", errors.New("Cannot read /proc/self/cgroup")
 	}
 
-	cgroups := string(bytes)
-	idRegex := regexp.MustCompile(`:[^:]*\bcpu\b[^:]*:[^\n]*\/([^\n]*)`)
+	return wrapper.ExtractContainerID(string(bytes))
+
+}
+
+func (wrapper *dockerUtils) ExtractContainerID(cgroups string) (string, error) {
+	idRegex := regexp.MustCompile(`(?i):[^:]*\bcpu\b[^:]*:[^/]*/.*([[:alnum:]]{64}).*`)
 	matches := idRegex.FindStringSubmatch(cgroups)
+
 	if len(matches) == 0 {
 		return "", fmt.Errorf("Cannot find container id in cgroups: %v", cgroups)
 	}

--- a/plugin/docker/utils_test.go
+++ b/plugin/docker/utils_test.go
@@ -1,0 +1,93 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestFailExtractBasicDockerId(t *testing.T) {
+	read :=
+		`5:cpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442.scope
+		4:cpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442
+		3:zpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		2:cpu,cpuacct:system.slice:d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		1:cpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf5 8b4d604d85293ced7cdb0c7fc52442b.scope
+		`
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err == nil {
+		t.Fatalf("Got unexpected container id %v", actual)
+	}
+
+}
+
+func TestExtractBasicDockerId(t *testing.T) {
+	read :=
+		`6:blkio:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		5:cpuset:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		4:net_cls,net_prio:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		3:freezer:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		2:cpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		`
+	expected := "d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b"
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err != nil {
+		t.Fatal("Could not extract container id")
+	}
+
+	if actual != expected {
+		t.Fatalf("id mismatch: actual %v, expected %v", actual, expected)
+	}
+}
+
+func TestExtractScopedDockerId(t *testing.T) {
+	read :=
+		`6:blkio:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
+		5:cpuset:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
+		4:net_cls,net_prio:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
+		3:freezer:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
+		2:cpu,cpuacct:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
+		`
+	expected := "d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b"
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err != nil {
+		t.Fatal("Could not extract container id")
+	}
+
+	if actual != expected {
+		t.Fatalf("id mismatch: actual %v, expected %v", actual, expected)
+	}
+}
+
+func TestExtractSlashPrefixedDockerId(t *testing.T) {
+	read :=
+		`6:blkio:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		5:cpuset:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		4:net_cls,net_prio:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		3:freezer:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		2:cpu,cpuacct:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		`
+	expected := "d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b"
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err != nil {
+		t.Fatal("Could not extract container id")
+	}
+
+	if actual != expected {
+		t.Fatalf("id mismatch: actual %v, expected %v", actual, expected)
+	}
+}

--- a/plugin/docker/utils_test.go
+++ b/plugin/docker/utils_test.go
@@ -29,7 +29,7 @@ func TestExtractBasicDockerId(t *testing.T) {
 		5:cpuset:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		4:net_cls,net_prio:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		3:freezer:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
-		2:cpu,cpuacct:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		2:cpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		`
 	expected := "d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b"
 

--- a/plugin/docker/utils_test.go
+++ b/plugin/docker/utils_test.go
@@ -29,7 +29,7 @@ func TestExtractBasicDockerId(t *testing.T) {
 		5:cpuset:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		4:net_cls,net_prio:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		3:freezer:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
-		2:cpu,cpuacct:/system.slice/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		2:cpu,cpuacct:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		`
 	expected := "d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b"
 
@@ -38,7 +38,7 @@ func TestExtractBasicDockerId(t *testing.T) {
 	actual, err := utils.ExtractContainerID(read)
 
 	if err != nil {
-		t.Fatal("Could not extract container id")
+		t.Fatalf("Could not extract container id : %v", err)
 	}
 
 	if actual != expected {
@@ -61,7 +61,7 @@ func TestExtractScopedDockerId(t *testing.T) {
 	actual, err := utils.ExtractContainerID(read)
 
 	if err != nil {
-		t.Fatal("Could not extract container id")
+		t.Fatalf("Could not extract container id : %v", err)
 	}
 
 	if actual != expected {
@@ -73,7 +73,7 @@ func TestExtractSlashPrefixedDockerId(t *testing.T) {
 	read :=
 		`6:blkio:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		5:cpuset:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
-		4:net_cls,net_prio:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
+		4:net_cls,net_prio:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		3:freezer:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		2:cpu,cpuacct:/system.slice/docker/d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b
 		`
@@ -84,7 +84,95 @@ func TestExtractSlashPrefixedDockerId(t *testing.T) {
 	actual, err := utils.ExtractContainerID(read)
 
 	if err != nil {
-		t.Fatal("Could not extract container id")
+		t.Fatalf("Could not extract container id : %v", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("id mismatch: actual %v, expected %v", actual, expected)
+	}
+}
+
+func TestExtractNestedDockerId(t *testing.T) {
+	read :=
+		`11:devices:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	10:perf_event:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	9:pids:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	8:cpuset:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	7:hugetlb:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	6:freezer:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	5:net_cls,net_prio:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	4:cpu,cpuacct:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	3:blkio:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	2:memory:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61
+	1:name=systemd:/docker/c59fb9264a25958577e23808e80d82acd5a27a3758e2095d1607df134221fae3/docker/ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61`
+
+	expected := "ac5c7f517c5707de3c77f33f0fa43e9c625d64d1e4d6c9c8ce7b50339ec86f61"
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err != nil {
+		t.Fatalf("Could not extract container id : %v", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("id mismatch: actual %v, expected %v", actual, expected)
+	}
+}
+
+func TestExtractAKSDockerId(t *testing.T) {
+	read :=
+		`12:perf_event:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	11:cpuset:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	10:memory:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	9:devices:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	8:net_cls,net_prio:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	7:hugetlb:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	6:freezer:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	5:blkio:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	4:cpu,cpuacct:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	3:rdma:/
+	2:pids:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	1:name=systemd:/kubepods/pod54ebaa4a-f470-11ea-b463-000d3a9ecdb6/43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857
+	`
+
+	expected := "43172aa658cbf50b2e646e3aa4c90447b10774d4e76ff720b0f4faebdb759857"
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err != nil {
+		t.Fatalf("Could not extract container id : %v", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("id mismatch: actual %v, expected %v", actual, expected)
+	}
+}
+
+func TestExtractECSDockerId(t *testing.T) {
+	read :=
+		`9:perf_event:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	8:memory:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	7:hugetlb:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	6:freezer:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	5:devices:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	4:cpuset:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	3:cpuacct:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	2:cpu:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	1:blkio:/ecs/8f67afbb-3222-488d-b96a-9262c37dc9d3/3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d
+	`
+
+	expected := "3137c30c56add55d7212fdef77fd796c69b08f7845aa9a3d3fdb720c2a885a1d"
+
+	utils := dockerUtils{}
+
+	actual, err := utils.ExtractContainerID(read)
+
+	if err != nil {
+		t.Fatalf("Could not extract container id : %v", err)
 	}
 
 	if actual != expected {


### PR DESCRIPTION
Hi @lucaslorentz. First of all, this looks like a great product! Unfortunately I haven't been able to use it out of the box as I failed at getting any reverse proxy setup to work. I tried to run the latest `standalone.yaml` example (both with versions `ci` and `3.2`) and encountered the following in the logs :

```
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] Running caddy proxy server
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | {"level":"info","ts":1598736880.3025773,"logger":"admin","msg":"admin endpoint started","address":"tcp/localhost:2019","enforce_origin":false,"origins":["localhost:2019","[::1]:2019","127.0.0.1:2019"]}
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | {"level":"info","ts":1598736880.3028717,"msg":"autosaved config","file":"/config/caddy/autosave.json"}
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] Running caddy proxy controller
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] CaddyfilePath: 
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] LabelPrefix: caddy
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] PollingInterval: 30s
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] ProcessCaddyfile: true
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] ProxyServiceTasks: true
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] IngressNetworks: []
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] Caddy ContainerID: docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] Swarm is available: true
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [ERROR] Error: No such container: docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | [INFO] Skipping default Caddyfile because no path is set
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | [WARNING] Container 335ec826b84157c86beeec7d3be04e361c8eed910f8f3f9d9447832909157142 and caddy are not in same network
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | [WARNING] Container 66058e7b0742ed54f5257eecb75175e6ebc8a4f3d1b4f6dabad06857f3373f8d and caddy are not in same network
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | [WARNING] Service nuu3ac3og3moqc334f2rannwb and caddy are not in same network
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | [WARNING] Service qxbw2vc63hx8r1xpipsxu9r8b doesn't have any task in running state
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | [WARNING] Service tay33i2dfwhpv8qtn67ipda22 and caddy are not in same network
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 2020/08/29 21:34:40 [INFO] New Caddyfile:
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | {
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	email you@example.com
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | }
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | config.example.com {
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	respond / "Hello World" 200
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	tls internal
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | }
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | echo0.example.com {
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	@match {
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 		path /sourcepath /sourcepath/*
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	}
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	route @match {
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 		uri strip_prefix /sourcepath
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 		rewrite * /targetpath{path}
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 		reverse_proxy
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	}
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	tls internal
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | }
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | whoami0.example.com {
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	reverse_proxy
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | 	tls internal
caddy-docker-demo_caddy.1.m2q5tf5tcbr5@my-laptop    | }
... etc ...
```
Looking into the first error it appears that an incorrect container id was determined for the caddy-docker-proxy container; when digging into how this is determined I found :

https://github.com/lucaslorentz/caddy-docker-proxy/blob/9419ff3f7a212d903f6a6d4cdeb4002f5af7ad38/plugin/docker/utils.go#L39

However, when examining `/proc/self/cgroup` in the container :
```
/ # cat /proc/self/cgroup  | grep "cpu\b"
2:cpu,cpuacct:/system.slice/docker-d39fa516d8377ecddf9bf8ef33f81cbf58b4d604d85293ced7cdb0c7fc52442b.scope
```
I didn't dive too deep in the reasons behind the name deviation, but I suspect it is a combination of my host OS (Fedora 32 `5.7.16-200.fc32.x86_64`) and/or Docker version (`19.03.11, build 42e35e6`).

Unfortunately it also seems that there is no set standard for introspecting containers, but I found some sources offering solutions for more flexible cgroups parsing, such as in [jwilder/docker-gen](https://github.com/jwilder/docker-gen/blob/4edc190faa34342313589a80e3a736cafb45919b/context.go#L188), or [Stack Overflow](https://stackoverflow.com/questions/20995351/how-can-i-get-docker-linux-container-information-from-within-the-container-itsel).

I took a stab at fixing this by changing the regex; let me know if you have any concerns or questions about this pull request!

Thanks.

