### PR TITLE
Add Custom templates to enable user specified labels to generate Caddyfile blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ reverse_proxy http://192.168.0.1:8080 http://192.168.0.2:8080
 ```
 
 :warning: Be carefull with quotes around upstreams. Quotes should only be added when using yaml. 
+
 ```
 caddy.reverse_proxy: "{{upstreams}}"
 ↓
@@ -401,15 +402,33 @@ caddy: example.com, example.org, www.example.com, www.example.org
 caddy.reverse_proxy: {{upstreams}}
 ```
 
-## Docker configs
+## Docker Swarm configs
 
-> Note: This is for Docker Swarm only. Alternativly, use `CADDY_DOCKER_CADDYFILE_PATH` or `-caddyfile-path`
+> Note: Docker Swarm only. For non-Swarm mode you can use use `CADDY_DOCKER_CADDYFILE_PATH` or `-caddyfile-path`
 
 You can also add raw text to your caddyfile using docker configs. Just add caddy label prefix to your configs and the whole config content will be inserted at the beginning of the generated caddyfile, outside any server blocks.
 
-[Here is an example](examples/standalone.yaml#L4)
+[Here is an example Swarm Compose file](examples/standalone.yaml#L4)
+
+or from the command line:
+
+```
+$ cat label.caddyfile 
+    @label_loc_alho_st {
+            host label.loc.alho.st
+    }
+    route @label_loc_alho_st {
+            respond "Testing swarm label"
+    }
+$ docker config create --label caddy label.loc.alho.st label.caddyfile
+$ curl https://label.loc.alho.st/
+Testing swarm label
+```
+
+
 
 ## Proxying services vs containers
+
 Caddy docker proxy is able to proxy to swarm services or raw containers. Both features are always enabled, and what will differentiate the proxy target is where you define your labels.
 
 ### Services
@@ -434,6 +453,61 @@ services:
       caddy: service.example.com
       caddy.reverse_proxy: {{upstreams}}
 ```
+
+### Docker image labels
+
+Instead of setting the labels on containers or services, you can also set them in your Dockerfile (see [LABELS](https://docs.docker.com/engine/reference/builder/#label)), and then when you create a container or service, they will be added automatically.
+
+For example
+
+```
+FROM nginx:latest
+
+LABEL caddy="lll.township-sl.ona.im"
+LABEL caddy.reverse_proxy="{{upstreams http 80}}"
+```
+
+will automatically work when you `docker run --network caddy_network --rm -it labeled_nginx:latest`, or create a service with it.
+
+## Golang template based configurations
+
+**TODO**
+
+### Static template files
+
+To define your own Caddyfile entries, or even process custom container labels into Caddyfile entries, you can use golang templates defined in `*.tmpl` in the `${XDG_CONFIG_HOME}/caddy/docker-proxy/` or `./caddy/docker-proxy/` (if `XGD_CONFIG_HOME` is not defined) directory. This directory is watched for changes, so you can add, remove or rename tmpl files, and they will be used.
+
+For example, to create a **TODO**
+
+### Docker Swarm label template files
+
+The `caddy.template` label can be added to Docker Swarm config's can be used to add text data into the templates evaluated by this plugin.
+
+The following example adds a template that will add another Caddy matcher and route to expose Prometheus metrics endpoints on a port denoted by the label `virtual.metrics` , able to be accessed using `https://container.domain/metrics`:
+
+```
+$ cat label.caddyfile.tmpl
+{{- if index labels "virtual.metrics" }}
+*.{{template "domain"}} {{template "domain"}} {
+	import dns_api_gandi
+	@{{matcher}}_metrics {
+			host {{template "hostmatcher"}}
+			path /metrics
+	}
+	route @{{matcher}}_metrics {
+			reverse_proxy {{upstreams ((index labels "virtual.metrics" | int)) }}
+	}
+	{{end}}
+}
+{{ end -}}
+$ docker config create --label caddy.template caddy-metrics-tmpl label.caddyfile.tmpl
+```
+
+
+
+
+
+
 
 ## Execution modes
 

--- a/plugin/caddyfile/fromlabels.go
+++ b/plugin/caddyfile/fromlabels.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strconv"
 	"text/template"
+
+	"github.com/Masterminds/sprig"
 )
 
 var whitespaceRegex = regexp.MustCompile("\\s+")
@@ -67,7 +69,7 @@ func parsePath(path string) (string, int, string) {
 }
 
 func processVariables(data interface{}, funcs template.FuncMap, content string) (string, error) {
-	t, err := template.New("").Funcs(funcs).Parse(content)
+	t, err := template.New("").Funcs(sprig.TxtFuncMap()).Funcs(funcs).Parse(content)
 	if err != nil {
 		return "", err
 	}

--- a/plugin/generator/containers.go
+++ b/plugin/generator/containers.go
@@ -24,8 +24,7 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container,
 	}
 
 	if len(ips) == 0 {
-		logger.Warn("Container is not in same network as caddy", zap.String("container", container.ID), zap.String("container id", container.ID))
-
+		logger.Warn("Container is not in same network as caddy", zap.String("container", container.Names[0]), zap.String("container id", container.ID))
 	}
 
 	return ips, nil

--- a/plugin/generator/containers.go
+++ b/plugin/generator/containers.go
@@ -24,7 +24,11 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container,
 	}
 
 	if len(ips) == 0 {
-		logger.Warn("Container is not in same network as caddy", zap.String("container", container.Names[0]), zap.String("container id", container.ID))
+		name := container.ID
+		if len(container.Names) > 0 {
+			name = container.Names[0]
+		}
+		logger.Warn("Container is not in same network as caddy", zap.String("container", name), zap.String("container id", container.ID))
 	}
 
 	return ips, nil

--- a/plugin/generator/containers_test.go
+++ b/plugin/generator/containers_test.go
@@ -34,7 +34,7 @@ func TestContainers_TemplateData(t *testing.T) {
 		"	reverse_proxy 172.17.0.2:5000/api\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -43,6 +43,9 @@ func TestContainers_PicksRightNetwork(t *testing.T) {
 	dockerClient := createBasicDockerClientMock()
 	dockerClient.ContainersData = []types.Container{
 		{
+			Names: []string{
+				"container-name",
+			},
 			NetworkSettings: &types.SummaryNetworkSettings{
 				Networks: map[string]*network.EndpointSettings{
 					"other-network": {
@@ -66,7 +69,7 @@ func TestContainers_PicksRightNetwork(t *testing.T) {
 		"	reverse_proxy 172.17.0.2\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -96,7 +99,7 @@ func TestContainers_DifferentNetwork(t *testing.T) {
 		"}\n"
 
 	const expectedLogs = commonLogs + skipCaddyfileLog +
-		`WARN	Container is not in same network as caddy	{"container": "CONTAINER-ID", "container id": "CONTAINER-ID"}` + newLine
+		`WARN	Container is not in same network as caddy	{"container": "CONTAINER-ID", "container id": "CONTAINER-ID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -131,7 +134,7 @@ func TestContainers_ManualIngressNetworks(t *testing.T) {
 		"	reverse_proxy 10.0.0.1\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog
+	const expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -175,7 +178,7 @@ func TestContainers_Replicas(t *testing.T) {
 		"	reverse_proxy 172.17.0.2 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -218,7 +221,7 @@ func TestContainers_DoNotMergeDifferentProxies(t *testing.T) {
 		"	reverse_proxy /b/* 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -284,7 +287,7 @@ func TestContainers_ComplexMerge(t *testing.T) {
 		"	tls internal\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -336,7 +339,7 @@ func TestContainers_WithSnippets(t *testing.T) {
 		"	reverse_proxy 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }

--- a/plugin/generator/containers_test.go
+++ b/plugin/generator/containers_test.go
@@ -34,7 +34,7 @@ func TestContainers_TemplateData(t *testing.T) {
 		"	reverse_proxy 172.17.0.2:5000/api\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -69,7 +69,7 @@ func TestContainers_PicksRightNetwork(t *testing.T) {
 		"	reverse_proxy 172.17.0.2\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -98,7 +98,7 @@ func TestContainers_DifferentNetwork(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	var expectedLogs = commonLogs + skipCaddyfileLog +
 		`WARN	Container is not in same network as caddy	{"container": "CONTAINER-ID", "container id": "CONTAINER-ID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
@@ -134,7 +134,7 @@ func TestContainers_ManualIngressNetworks(t *testing.T) {
 		"	reverse_proxy 10.0.0.1\n" +
 		"}\n"
 
-	const expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -178,7 +178,7 @@ func TestContainers_Replicas(t *testing.T) {
 		"	reverse_proxy 172.17.0.2 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -221,7 +221,7 @@ func TestContainers_DoNotMergeDifferentProxies(t *testing.T) {
 		"	reverse_proxy /b/* 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -287,7 +287,7 @@ func TestContainers_ComplexMerge(t *testing.T) {
 		"	tls internal\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -339,7 +339,7 @@ func TestContainers_WithSnippets(t *testing.T) {
 		"	reverse_proxy 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -36,8 +36,14 @@ type CaddyfileGenerator struct {
 }
 
 // CreateGenerator creates a new generator
-func CreateGenerator(dockerClient docker.Client, dockerUtils docker.Utils, options *config.Options) *CaddyfileGenerator {
+func CreateGenerator(dockerClient docker.Client, dockerUtils docker.Utils, logger *zap.Logger, options *config.Options) *CaddyfileGenerator {
 	var labelRegexString = fmt.Sprintf("^%s(_\\d+)?(\\.|$)", options.LabelPrefix)
+
+	err := setupTemplateDirWatcher(logger)
+	if err != nil {
+		logger.Info("no template dir to watch", zap.Error(err))
+		// don't exit, we'll try again later..
+	}
 
 	return &CaddyfileGenerator{
 		options:      options,

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -194,12 +194,16 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 				//logger.Debug("Skipping, as its a Swarm service task", zap.String("container", container.Names[0]), zap.String("service", serviceName))
 				continue
 			}
-			logger.Debug("Container", zap.String("container", container.Names[0]))
+			name := container.ID
+			if len(container.Names) > 0 {
+				name = container.Names[0]
+			}
+			logger.Debug("Container", zap.String("container", name))
 
 			if _, isControlledServer := container.Labels[g.options.ControlledServersLabel]; isControlledServer {
 				ips, err := g.getContainerIPAddresses(&container, logger, false)
 				if err != nil {
-					logger.Error("Failed to get Container IPs", zap.String("container", container.Names[0]), zap.Error(err))
+					logger.Error("Failed to get Container IPs", zap.String("container", name), zap.Error(err))
 				} else {
 					for _, ip := range ips {
 						if g.options.ControllerNetwork == nil || g.options.ControllerNetwork.Contains(net.ParseIP(ip)) {
@@ -214,7 +218,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 			if err == nil {
 				caddyfileBlock.Merge(containerCaddyfile)
 			} else {
-				logger.Error("Failed to get Container Caddyfile", zap.String("container", container.Names[0]), zap.Error(err))
+				logger.Error("Failed to get Container Caddyfile", zap.String("container", name), zap.Error(err))
 			}
 
 			// template files based config
@@ -224,7 +228,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 
 				caddyfileBlock.Merge(containerTemplateCaddyfile)
 			} else {
-				logger.Error("Failed to get templated Container Caddyfile", zap.String("container", container.Names[0]), zap.Error(err))
+				logger.Error("Failed to get templated Container Caddyfile", zap.String("container", name), zap.Error(err))
 			}
 		}
 	} else {

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/lucaslorentz/caddy-docker-proxy/plugin/v2/caddyfile"
@@ -260,9 +262,8 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 		controlledServers = append(controlledServers, "localhost")
 	}
 
-	// TODO: make optional
-	// TODO: get the file location...
-	ioutil.WriteFile("/config/caddy/docker-plugin.caddyfile", caddyfileContent, 0644)
+	// caddy/docker-plugin.caddyfile
+	ioutil.WriteFile(filepath.Join(caddy.AppConfigDir(), "docker-plugin.caddyfile"), caddyfileContent, 0644)
 
 	return caddyfileContent, controlledServers
 }

--- a/plugin/generator/generator_test.go
+++ b/plugin/generator/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
@@ -28,8 +29,11 @@ const otherIngressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[othe
 const swarmIsAvailableLog = `INFO	Swarm is available	{"new": true}` + newLine
 const swarmIsDisabledLog = `INFO	Swarm is available	{"new": false}` + newLine
 const skipCaddyfileLog = "INFO	Skipping default Caddyfile because no path is set" + newLine
-const noTemplateDirToWatch = `INFO	no template dir to watch	{"error": "stat /home/dow184/.config/caddy/docker-proxy: no such file or directory"}` + newLine
-const commonLogs = noTemplateDirToWatch + containerIdLog + ingressNetworksMapLog + swarmIsAvailableLog
+
+var configPath = caddy.AppConfigDir()
+
+var noTemplateDirToWatch = `INFO	no template dir to watch	{"error": "stat ` + configPath + `/docker-proxy: no such file or directory"}` + newLine
+var commonLogs = noTemplateDirToWatch + containerIdLog + ingressNetworksMapLog + swarmIsAvailableLog
 
 func init() {
 	log.SetOutput(ioutil.Discard)
@@ -90,7 +94,7 @@ func TestMergeConfigContent(t *testing.T) {
 		"	reverse_proxy 127.0.0.1 172.17.0.2\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -122,7 +126,7 @@ func TestIgnoreLabelsWithoutCaddyPrefix(t *testing.T) {
 
 	const expectedCaddyfile = "# Empty caddyfile"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }

--- a/plugin/generator/services_test.go
+++ b/plugin/generator/services_test.go
@@ -58,7 +58,7 @@ func TestServices_TemplateData(t *testing.T) {
 		"	}\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -91,7 +91,7 @@ func TestServices_DifferentNetwork(t *testing.T) {
 		"	reverse_proxy service\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	var expectedLogs = commonLogs + skipCaddyfileLog +
 		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICE-ID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
@@ -131,7 +131,7 @@ func TestServices_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy service\n" +
 		"}\n"
 
-	const expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -169,7 +169,7 @@ func TestServices_SwarmDisabled(t *testing.T) {
 
 	const expectedCaddyfile = "# Empty caddyfile"
 
-	const expectedLogs = noTemplateDirToWatch + containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog + skipCaddyfileLog +
+	var expectedLogs = noTemplateDirToWatch + containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog + skipCaddyfileLog +
 		"INFO	Skipping swarm config caddyfiles because swarm is not available\n" +
 		"INFO	Skipping swarm config templates because swarm is not available\n" +
 		"INFO	Skipping swarm services because swarm is not available\n"
@@ -205,7 +205,7 @@ func TestServiceTasks_Empty(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	var expectedLogs = commonLogs + skipCaddyfileLog +
 		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
@@ -269,7 +269,7 @@ func TestServiceTasks_NotRunning(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	var expectedLogs = commonLogs + skipCaddyfileLog +
 		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
@@ -320,7 +320,7 @@ func TestServiceTasks_DifferentNetwork(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	var expectedLogs = commonLogs + skipCaddyfileLog +
 		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICEID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
@@ -377,7 +377,7 @@ func TestServiceTasks_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000\n" +
 		"}\n"
 
-	const expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -441,7 +441,7 @@ func TestServiceTasks_Running(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000 10.0.0.2:5000\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
+	var expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true

--- a/plugin/generator/services_test.go
+++ b/plugin/generator/services_test.go
@@ -58,7 +58,7 @@ func TestServices_TemplateData(t *testing.T) {
 		"	}\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -92,7 +92,7 @@ func TestServices_DifferentNetwork(t *testing.T) {
 		"}\n"
 
 	const expectedLogs = commonLogs + skipCaddyfileLog +
-		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICE-ID"}` + newLine
+		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICE-ID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -131,7 +131,7 @@ func TestServices_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy service\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog
+	const expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -169,8 +169,9 @@ func TestServices_SwarmDisabled(t *testing.T) {
 
 	const expectedCaddyfile = "# Empty caddyfile"
 
-	const expectedLogs = containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog + skipCaddyfileLog +
+	const expectedLogs = noTemplateDirToWatch + containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog + skipCaddyfileLog +
 		"INFO	Skipping swarm config caddyfiles because swarm is not available\n" +
+		"INFO	Skipping swarm config templates because swarm is not available\n" +
 		"INFO	Skipping swarm services because swarm is not available\n"
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
@@ -205,7 +206,7 @@ func TestServiceTasks_Empty(t *testing.T) {
 		"}\n"
 
 	const expectedLogs = commonLogs + skipCaddyfileLog +
-		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine
+		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -269,7 +270,7 @@ func TestServiceTasks_NotRunning(t *testing.T) {
 		"}\n"
 
 	const expectedLogs = commonLogs + skipCaddyfileLog +
-		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine
+		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -320,7 +321,7 @@ func TestServiceTasks_DifferentNetwork(t *testing.T) {
 		"}\n"
 
 	const expectedLogs = commonLogs + skipCaddyfileLog +
-		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICEID"}` + newLine
+		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICEID"}` + newLine + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -376,7 +377,7 @@ func TestServiceTasks_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog
+	const expectedLogs = noTemplateDirToWatch + otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -440,7 +441,7 @@ func TestServiceTasks_Running(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000 10.0.0.2:5000\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs + skipCaddyfileLog + noTemplateDirToWatch
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true

--- a/plugin/generator/templates.go
+++ b/plugin/generator/templates.go
@@ -64,9 +64,6 @@ func (g *CaddyfileGenerator) getServiceTemplatedCaddyfile(service *swarm.Service
 					return host, nil
 				}
 			}
-			// TODO: how do we deal if we have a full domain name?
-
-			// TODO: from compose, looks like caddy-docker-proxy_maintainence_1 (remove _1?)
 			return strings.TrimPrefix(service.Spec.Name, "/"), nil
 		},
 	}
@@ -116,9 +113,6 @@ func (g *CaddyfileGenerator) getContainerTemplatedCaddyfile(container *types.Con
 					return host, nil
 				}
 			}
-			// TODO: how do we deal if we have a full domain name?
-
-			// TODO: from compose, looks like caddy-docker-proxy_maintainence_1 (remove _1?)
 			return strings.TrimPrefix(container.Names[0], "/"), nil
 		},
 	}
@@ -144,13 +138,6 @@ func NewTemplate(name, tmpl string) {
 
 func init() {
 	newTemplate = make(chan tmplData, 20)
-
-	// // TODO: not the right log
-	// err := setupTemplateDirWatcher(caddy.Logs())
-	// if err != nil {
-	// 	logger.Info("no template dir to watch", zap.Error(err))
-	// 	// don't exit, we'll try again later..
-	// }
 
 	commonFuncMap := template.FuncMap{
 		"http": func() string {

--- a/plugin/generator/templates.go
+++ b/plugin/generator/templates.go
@@ -77,7 +77,11 @@ func (g *CaddyfileGenerator) getContainerTemplatedCaddyfile(container *types.Con
 		// don't exit, we'll try again later..
 	}
 
-	matcher := strings.TrimPrefix(container.Names[0], "/")
+	name := container.ID
+	if len(container.Names) > 0 {
+		name = container.Names[0]
+	}
+	matcher := strings.TrimPrefix(name, "/")
 	logger.Debug("getContainerTemplatedCaddyfile", zap.String("matcher", matcher), zap.String("labels", fmt.Sprintf("%v", container.Labels)))
 
 	funcMap := template.FuncMap{
@@ -113,7 +117,7 @@ func (g *CaddyfileGenerator) getContainerTemplatedCaddyfile(container *types.Con
 					return host, nil
 				}
 			}
-			return strings.TrimPrefix(container.Names[0], "/"), nil
+			return strings.TrimPrefix(name, "/"), nil
 		},
 	}
 	return g.getTemplatedCaddyfile(container, funcMap, logger)

--- a/plugin/generator/templates.go
+++ b/plugin/generator/templates.go
@@ -1,0 +1,294 @@
+package generator
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"github.com/caddyserver/caddy/v2"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/fsnotify/fsnotify"
+	"github.com/lucaslorentz/caddy-docker-proxy/plugin/v2/caddyfile"
+
+	"go.uber.org/zap"
+)
+
+func (g *CaddyfileGenerator) getServiceTemplatedCaddyfile(service *swarm.Service, logger *zap.Logger) (*caddyfile.Container, error) {
+	err := setupTemplateDirWatcher(logger)
+	if err != nil {
+		logger.Info("no template dir to watch", zap.Error(err))
+		// don't exit, we'll try again later..
+	}
+
+	matcher := strings.TrimPrefix(service.Spec.Name, "/")
+	logger.Debug("getServiceTemplatedCaddyfile", zap.String("matcher", matcher), zap.String("labels", fmt.Sprintf("%v", service.Spec.Labels)))
+
+	funcMap := template.FuncMap{
+		"entitytype": func(options ...interface{}) (string, error) {
+			return "service", nil
+		},
+		"upstreams": func(options ...interface{}) (string, error) {
+			targets, err := g.getServiceProxyTargets(service, logger, true)
+			transformed := []string{}
+			for _, target := range targets {
+				for _, param := range options {
+					if protocol, isProtocol := param.(string); isProtocol {
+						target = protocol + "://" + target
+					} else if port, isPort := param.(int); isPort {
+						target = target + ":" + strconv.Itoa(port)
+					}
+				}
+				transformed = append(transformed, target)
+			}
+			logger.Debug("getServiceTemplatedCaddyfile", zap.Strings("upstreams", transformed))
+
+			return strings.Join(transformed, " "), err
+		},
+		"matcher": func(options ...interface{}) (string, error) {
+			return matcher, nil
+		},
+		"labels": func(options ...interface{}) (map[string]string, error) {
+			return service.Spec.Labels, nil
+		},
+		"hostname": func(options ...interface{}) (string, error) {
+			// if there is a string param, use it.
+			if len(options) == 1 {
+				if host, isString := options[0].(string); isString && host != "" {
+					return host, nil
+				}
+			}
+			// TODO: how do we deal if we have a full domain name?
+
+			// TODO: from compose, looks like caddy-docker-proxy_maintainence_1 (remove _1?)
+			return strings.TrimPrefix(service.Spec.Name, "/"), nil
+		},
+	}
+	return g.getTemplatedCaddyfile(service, funcMap, logger)
+}
+
+func (g *CaddyfileGenerator) getContainerTemplatedCaddyfile(container *types.Container, logger *zap.Logger) (*caddyfile.Container, error) {
+	err := setupTemplateDirWatcher(logger)
+	if err != nil {
+		logger.Info("no template dir to watch", zap.Error(err))
+		// don't exit, we'll try again later..
+	}
+
+	matcher := strings.TrimPrefix(container.Names[0], "/")
+	logger.Debug("getContainerTemplatedCaddyfile", zap.String("matcher", matcher), zap.String("labels", fmt.Sprintf("%v", container.Labels)))
+
+	funcMap := template.FuncMap{
+		"entitytype": func(options ...interface{}) (string, error) {
+			return "container", nil
+		},
+		"upstreams": func(options ...interface{}) (string, error) {
+			targets, err := g.getContainerIPAddresses(container, logger, true)
+			transformed := []string{}
+			for _, target := range targets {
+				for _, param := range options {
+					if protocol, isProtocol := param.(string); isProtocol {
+						target = protocol + "://" + target
+					} else if port, isPort := param.(int); isPort {
+						target = target + ":" + strconv.Itoa(port)
+					}
+				}
+				transformed = append(transformed, target)
+			}
+			logger.Debug("getContainerTemplatedCaddyfile", zap.Strings("upstreams", transformed))
+			return strings.Join(transformed, " "), err
+		},
+		"matcher": func(options ...interface{}) (string, error) {
+			return matcher, nil
+		},
+		"labels": func(options ...interface{}) (map[string]string, error) {
+			return container.Labels, nil
+		},
+		"hostname": func(options ...interface{}) (string, error) {
+			// if there is a string param, use it.
+			if len(options) == 1 {
+				if host, isString := options[0].(string); isString && host != "" {
+					return host, nil
+				}
+			}
+			// TODO: how do we deal if we have a full domain name?
+
+			// TODO: from compose, looks like caddy-docker-proxy_maintainence_1 (remove _1?)
+			return strings.TrimPrefix(container.Names[0], "/"), nil
+		},
+	}
+	return g.getTemplatedCaddyfile(container, funcMap, logger)
+}
+
+type tmplData struct {
+	name string
+	tmpl string
+}
+
+var loadedTemplates *template.Template
+var newTemplate chan tmplData
+var templateDirWatcher *fsnotify.Watcher
+
+// NewTemplate adds a new named template to the parsing queue
+func NewTemplate(name, tmpl string) {
+	newTemplate <- tmplData{
+		name: name,
+		tmpl: tmpl,
+	}
+}
+
+func init() {
+	newTemplate = make(chan tmplData, 20)
+
+	// // TODO: not the right log
+	// err := setupTemplateDirWatcher(caddy.Logs())
+	// if err != nil {
+	// 	logger.Info("no template dir to watch", zap.Error(err))
+	// 	// don't exit, we'll try again later..
+	// }
+
+	commonFuncMap := template.FuncMap{
+		"http": func() string {
+			return "http"
+		},
+		"https": func() string {
+			return "https"
+		},
+	}
+	loadedTemplates = template.New("").Funcs(sprig.TxtFuncMap()).Funcs(commonFuncMap)
+
+}
+
+func (g *CaddyfileGenerator) getTemplatedCaddyfile(data interface{}, funcMap template.FuncMap, logger *zap.Logger) (*caddyfile.Container, error) {
+	// TODO: how to deal with _1, _2 etc - multiple routes on one container...
+
+	// TODO: need to extract the funcMap, or abstract it better, as we need to over-ride it to cater for the difference between container and service
+	loadedTemplates = loadedTemplates.Funcs(funcMap)
+
+	// Parse any found or updated templates TMPL: prefix is to diferentiate from funcMap / named templates
+	for {
+		select {
+		case tmpl := <-newTemplate:
+			logger.Debug("parsing template", zap.String("name", tmpl.name))
+
+			t := loadedTemplates.New("TMPL:" + tmpl.name)
+			_, err := t.Parse(tmpl.tmpl)
+			if err != nil {
+				logger.Error("parsing template", zap.String("name", tmpl.name), zap.Error(err))
+			}
+		default:
+			// no changed templates found
+			goto noTemplates
+		}
+	}
+noTemplates:
+
+	var block caddyfile.Container
+	for _, tmpl := range loadedTemplates.Templates() {
+		if !strings.HasPrefix(tmpl.Name(), "TMPL:") {
+			continue
+		}
+		var writer bytes.Buffer
+		err := loadedTemplates.ExecuteTemplate(&writer, tmpl.Name(), data)
+		if err != nil {
+			logger.Error("ExecuteTemplate", zap.String("name", tmpl.Name()), zap.Error(err))
+			continue
+		}
+
+		newblock, err := caddyfile.Unmarshal(writer.Bytes())
+		if err != nil {
+			logger.Error("problem converting template to caddyfile block", zap.String("name", tmpl.Name()), zap.Error(err))
+			continue
+		}
+		block.Merge(newblock)
+	}
+
+	return &block, nil
+}
+
+func setupTemplateDirWatcher(logger *zap.Logger) error {
+	if templateDirWatcher != nil {
+		// Already initialised
+		return nil
+	}
+	// watch for templates in "${XDG_CONFIG_HOME}/caddy/docker-proxy/"
+	rootDir := filepath.Join(caddy.AppConfigDir(), "docker-proxy")
+	cleanRoot := filepath.Clean(rootDir)
+	info, err := os.Stat(cleanRoot)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("docker-proxy template dir (%s) is not a Directory", cleanRoot)
+	}
+
+	templateDirWatcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		logger.Fatal("Failed to create watcher", zap.Error(err))
+	}
+	go func() {
+		for {
+			select {
+			case event, ok := <-templateDirWatcher.Events:
+				if !ok {
+					logger.Info("Stopping watching for filesystem changes")
+					return
+				}
+				if !strings.HasSuffix(event.Name, ".tmpl") {
+					logger.Debug("ignoring non .tmpl file", zap.String("name", event.Name))
+					continue
+				}
+
+				removeBytes := []byte("## removed " + event.Name + " file\n\n")
+				b := removeBytes
+				b, err = ioutil.ReadFile(event.Name)
+				if err != nil {
+					logger.Error("reading event, will remove from templates", zap.String("name", event.Name), zap.Error(err))
+
+					b = removeBytes
+				}
+
+				NewTemplate(event.Name, string(b))
+			case err, ok := <-templateDirWatcher.Errors:
+				if !ok {
+					logger.Info("Stopping watching for filesystem changes")
+					return
+				}
+				logger.Error("watcher error", zap.Error(err))
+			}
+		}
+	}()
+
+	err = templateDirWatcher.Add(cleanRoot)
+	if err != nil {
+		logger.Error("watcher error", zap.String("dir", cleanRoot), zap.Error(err))
+		logger.Fatal("watcher error", zap.String("dir", cleanRoot), zap.Error(err))
+	}
+	logger.Info("Watching for updates to files ending with .tmp", zap.String("dir", cleanRoot))
+
+	// Also need to read the existing files
+	err = filepath.Walk(cleanRoot, func(path string, info os.FileInfo, e1 error) error {
+		if !info.IsDir() && strings.HasSuffix(path, ".tmpl") {
+			logger.Debug("found template file", zap.String("file", path))
+
+			if e1 != nil {
+				logger.Error("problem walking dir", zap.Error(e1))
+				return nil // continue with other files
+			}
+
+			b, e2 := ioutil.ReadFile(path)
+			if e2 != nil {
+				logger.Error("problem reading file", zap.String("file", path), zap.Error(e1))
+				return nil // continue with other files
+			}
+			NewTemplate(path, string(b))
+		}
+		return nil
+	})
+	return nil
+}

--- a/plugin/generator/templates.go
+++ b/plugin/generator/templates.go
@@ -152,9 +152,6 @@ func init() {
 }
 
 func (g *CaddyfileGenerator) getTemplatedCaddyfile(data interface{}, funcMap template.FuncMap, logger *zap.Logger) (*caddyfile.Container, error) {
-	// TODO: how to deal with _1, _2 etc - multiple routes on one container...
-
-	// TODO: need to extract the funcMap, or abstract it better, as we need to over-ride it to cater for the difference between container and service
 	loadedTemplates = loadedTemplates.Funcs(funcMap)
 
 	// Parse any found or updated templates TMPL: prefix is to diferentiate from funcMap / named templates

--- a/plugin/loader.go
+++ b/plugin/loader.go
@@ -77,6 +77,7 @@ func (dockerLoader *DockerLoader) Start() error {
 		dockerLoader.generator = generator.CreateGenerator(
 			wrappedClient,
 			docker.CreateUtils(),
+			log,
 			dockerLoader.options,
 		)
 


### PR DESCRIPTION
@lucaslorentz I started to work out how to implement your proposal - initially for non-swarm containers

see https://github.com/SvenDowideit/caddy-docker-proxy/blob/cdp-macros-experimentation/plugin/generator/templates.go

annoyingly, compose-file config's are Swarm mode only - and one of my targets is hooking up `docker run`, so we need another way to mix in template definitions when not using Swarm.

I'm hoping to have it done before the end of September :)

copied from original issue discussion

examples of use: 
* `docker run -it --label virtual.port=80 --name nginx --network cirri_proxy nginx` 
* docker-compose
* docker swarm service

```
{{ if index labels "virtual.port" }}
*.loc.alho.st loc.alho.st {
			import dns_api_gandi
			@{{matcher}} {
					host {{hostname ((index labels "virtual.host"))}}.loc.alho.st
					{{ if index labels "virtual.path" }}
					path {{ index labels "virtual.path" }}
					{{ end }}
			}
			route @{{matcher}} {
					reverse_proxy {{upstreams ((index labels "virtual.port" | int)) }}
			}
}
{{ end }}
```


- [x] for Swarm mode, templates can be added using Swarm config's by using the label `caddy.template` (internally the template is identified using the config name, so it can be updated)
- [x] Templates need a non-swarm way to inject templates - the `$XDG_CONFIG_DIR/caddy/docker-proxy/` is watched for file changes and are loaded as templates
- [x] For each container/service found in swarm cluster, all templates will be invoked with that docker object as input data.
    If a template output is a non empty/whitespace string, the output is converted to caddyfile and merged into the final generated caddyfile, along with other contents generated by the traditional label to caddyfile conversion.
- [x] It's template responsibility to decide if it should render or not a caddyfile for that docker object
- Templates would have the following functions available:
  - [x] sprig: we had that before, I think something accidentally dropped it
  - [x] `upstreams`: to easily generate upstreams addresses
  - [x] `labels`: a uniform way of retrieving all labels of current docker object (container or service)
  - [x] `labels`: add image labels 
  - [x] `entitytype`: a way to identify the type of docker object the template is running against (container or service). This might be required in order to write templates compatible with both.
  - [x] hostName: a way to get container_name, service_name, or set from param (in this PR's example case, a label `virtual.host`)
- [x] documentation