### PR TITLE
Ensure matchers are before ordered directives

### DIFF
--- a/plugin/caddyfile/caddyfile.go
+++ b/plugin/caddyfile/caddyfile.go
@@ -101,5 +101,5 @@ func (block *Block) IsSnippet() bool {
 
 // IsMatcher returns if block is a matcher
 func (block *Block) IsMatcher() bool {
-	return len(block.Keys) == 1 && strings.HasPrefix(block.Keys[0], "@")
+	return len(block.Keys) > 0 && strings.HasPrefix(block.Keys[0], "@")
 }

--- a/plugin/caddyfile/caddyfile.go
+++ b/plugin/caddyfile/caddyfile.go
@@ -98,3 +98,8 @@ func (block *Block) IsGlobalBlock() bool {
 func (block *Block) IsSnippet() bool {
 	return len(block.Keys) == 1 && strings.HasPrefix(block.Keys[0], "(") && strings.HasSuffix(block.Keys[0], ")")
 }
+
+// IsMatcher returns if block is a matcher
+func (block *Block) IsMatcher() bool {
+	return len(block.Keys) == 1 && strings.HasPrefix(block.Keys[0], "@")
+}

--- a/plugin/caddyfile/marshal.go
+++ b/plugin/caddyfile/marshal.go
@@ -95,6 +95,13 @@ func compareBlocks(blockA *Block, blockB *Block) int {
 		}
 		return 1
 	}
+	// Then matchers first
+	if blockA.IsMatcher() != blockB.IsMatcher() {
+		if blockA.IsMatcher() {
+			return -1
+		}
+		return 1
+	}
 	// Then follow order
 	if blockA.Order != blockB.Order {
 		if blockA.Order < blockB.Order {

--- a/plugin/caddyfile/testdata/labels/matchers_come_first.txt
+++ b/plugin/caddyfile/testdata/labels/matchers_come_first.txt
@@ -1,10 +1,12 @@
 caddy               = localhost
 caddy.@matcher.path = /path1 /path2
 caddy.respond       = @matcher 200
+caddy.1_tls			= internal
 ----------
 localhost {
 	@matcher {
 		path /path1 /path2
 	}
+	tls internal
 	respond @matcher 200
 }

--- a/plugin/caddyfile/testdata/labels/one_line_matchers_come_first.txt
+++ b/plugin/caddyfile/testdata/labels/one_line_matchers_come_first.txt
@@ -1,0 +1,10 @@
+caddy               = localhost
+caddy.@matcher 		= path /path1
+caddy.respond       = @matcher 200
+caddy.1_tls			= internal
+----------
+localhost {
+	@matcher path /path1
+	tls internal
+	respond @matcher 200
+}

--- a/tests/caddyfile+config/compose.yaml
+++ b/tests/caddyfile+config/compose.yaml
@@ -32,6 +32,7 @@ services:
         caddy: service.local
         caddy.import_0: caddyfileSnippet
         caddy.import_1: configSnippet
+        caddy.tls: "internal"
 
 networks:
   caddy:


### PR DESCRIPTION
If we declare something like:
```
  whoami0:
    image: jwilder/whoami
    networks:
      - caddy
    deploy:
      labels:
        caddy: example.com
        caddy.@matcher1.path: "*"
        caddy.@matcher2.path: "/folder/*"
        caddy.2_reverse_proxy: "@matcher1 {{upstreams 8000}}"
        caddy.1_reverse_proxy: "@matcher2 {{upstreams 8000}}"
```

The marshaller will prioritize ordered directives over matchers. Generating:
```
example.com {
	reverse_proxy @matcher2 10.0.3.8:8000
	reverse_proxy @matcher1 10.0.3.6:8000
	@matcher1 {
		path *
	}
	@matcher2 {
		path /folder/*
	}
}
```

That behavior forces us to also define matchers order with #_ prefix.
This PR changes it to put matchers before other ordered directives. Generating this instead:
```
example.com {
	@matcher1 {
		path *
	}
	@matcher2 {
		path /folder/*
	}
	reverse_proxy @matcher2 10.0.3.8:8000
	reverse_proxy @matcher1 10.0.3.6:8000
}
```