### PR TITLE
Basic example at top of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,57 @@ Then it generates an in memory Caddyfile with website entries and proxies direct
 
 Every time a docker object changes, it updates the Caddyfile and triggers a caddy zero-downtime reload.
 
+## Basic Usage Example, using docker-compose:
+```
+docker network create caddy
+```
+caddy/docker-compose.yml
+```
+version: "3.7"
+services:
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - caddy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy_data:/data
+    restart: unless-stopped
+
+networks:
+  caddy:
+    external: true
+	
+volumes:
+  caddy_data: {}
+```
+```
+docker-compose up -d
+```
+whoami/docker-compose.yml
+```
+version: '3.7'
+services:
+  whoami:
+    image: jwilder/whoami
+    networks:
+      - caddy
+    labels:
+      caddy: whoami.example.com
+      caddy.reverse_proxy: "{{upstreams 8000}}"
+
+networks:
+  caddy:
+    external: true
+```
+```
+docker-compose up -d
+```
+visit whoami.example.com. The site with be served automatically over https with a Let's Encrypt Certificate
+		
 ## Labels to Caddyfile conversion
 Any label prefixed with caddy, will be converted to caddyfile configuration following those rules:
 


### PR DESCRIPTION
I find the readme to be complex and it may be off-putting for other newcomers. The Examples/standalone.yaml seems to include swarm info (deploy / node etc) - perhaps I've misunderstood standalone - and so doesn't function in a simpler setup.

I've included the simplest docker-compose.yml files at top of Readme to show the easiest way to get this up and running and to encourage further reading. It's deliberately split out over 2 separate files to demonstrate that any new app created will automatically be picked up by Caddy (presumably through docker-gen?)