### PR TITLE
Polish the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,57 @@
-# CADDY-DOCKER-PROXY [![Build Status](https://dev.azure.com/lucaslorentzlara/lucaslorentzlara/_apis/build/status/lucaslorentz.caddy-docker-proxy?branchName=master)](https://dev.azure.com/lucaslorentzlara/lucaslorentzlara/_build/latest?definitionId=1) [![Go Report Card](https://goreportcard.com/badge/github.com/lucaslorentz/caddy-docker-proxy)](https://goreportcard.com/report/github.com/lucaslorentz/caddy-docker-proxy)
-
-## CADDY V2!
-
-This plugin has been updated to Caddy V2.  
-
-**Master branch** and **docker CI images** are now dedicated to V2.
-
-[Go to Caddy V1 readme](https://github.com/lucaslorentz/caddy-docker-proxy/blob/v0/README.md)
+# Caddy-Docker-Proxy 
+[![Build Status](https://dev.azure.com/lucaslorentzlara/lucaslorentzlara/_apis/build/status/lucaslorentz.caddy-docker-proxy?branchName=master)](https://dev.azure.com/lucaslorentzlara/lucaslorentzlara/_build/latest?definitionId=1) [![Go Report Card](https://goreportcard.com/badge/github.com/lucaslorentz/caddy-docker-proxy)](https://goreportcard.com/report/github.com/lucaslorentz/caddy-docker-proxy)
 
 ## Introduction
-This plugin enables caddy to be used as a reverse proxy for Docker.
+This plugin enables Caddy to be used as a reverse proxy for Docker containers via labels.
 
 ## How does it work?
-It scans Docker metadata looking for labels indicating that the service or container should be exposed on caddy.
+The plugin scans Docker metadata, looking for labels indicating that the service or container should be served by Caddy.
 
-Then it generates an in memory Caddyfile with website entries and proxies directives pointing to each Docker service DNS name or container IP.
+Then, it generates an in-memory Caddyfile with site entries and proxies pointing to each Docker service by their DNS name or container IP.
 
-Every time a docker object changes, it updates the Caddyfile and triggers a caddy zero-downtime reload.
+Every time a docker object changes, the plugin updates the Caddyfile and triggers Caddy to gracefully reload, with zero-downtime.
 
-## Basic Usage Example, using docker-compose:
+## Table of contents
+
+  * [Basic usage example, using docker-compose](#basic-usage-example-using-docker-compose)
+  * [Labels to Caddyfile conversion](#labels-to-caddyfile-conversion)
+    + [Tokens and arguments](#tokens-and-arguments)
+    + [Ordering and isolation](#ordering-and-isolation)
+    + [Sites, snippets and global options](#sites-snippets-and-global-options)
+    + [Go templates](#go-templates)
+  * [Template functions](#template-functions)
+    + [upstreams](#upstreams)
+  * [Reverse proxy examples](#reverse-proxy-examples)
+  * [Docker configs](#docker-configs)
+  * [Proxying services vs containers](#proxying-services-vs-containers)
+    + [Services](#services)
+    + [Containers](#containers)
+  * [Execution modes](#execution-modes)
+    + [Server](#server)
+    + [Controller](#controller)
+    + [Standalone (default)](#standalone-default)
+  * [Caddy CLI](#caddy-cli)
+  * [Docker images](#docker-images)
+    + [Choosing the version numbers](#choosing-the-version-numbers)
+    + [Chosing between default or alpine images](#chosing-between-default-or-alpine-images)
+    + [CI images](#ci-images)
+    + [ARM architecture images](#arm-architecture-images)
+    + [Windows images](#windows-images)
+    + [Custom images](#custom-images)
+  * [Connecting to Docker Host](#connecting-to-docker-host)
+  * [Volumes](#volumes)
+  * [Trying it](#trying-it)
+    + [With docker-compose file](#with-docker-compose-file)
+    + [With run commands](#with-run-commands)
+  * [Building it](#building-it)
+
+## Basic usage example, using docker-compose
+```shell
+$ docker network create caddy
 ```
-docker network create caddy
-```
-caddy/docker-compose.yml
-```
+
+`caddy/docker-compose.yml`
+```yml
 version: "3.7"
 services:
   caddy:
@@ -43,15 +71,16 @@ services:
 networks:
   caddy:
     external: true
-	
+
 volumes:
   caddy_data: {}
 ```
+```shell
+$ docker-compose up -d
 ```
-docker-compose up -d
-```
-whoami/docker-compose.yml
-```
+
+`whoami/docker-compose.yml`
+```yml
 version: '3.7'
 services:
   whoami:
@@ -66,15 +95,19 @@ networks:
   caddy:
     external: true
 ```
+```shell
+$ docker-compose up -d
 ```
-docker-compose up -d
-```
-visit whoami.example.com. The site with be served automatically over https with a Let's Encrypt Certificate
+Now, visit `https://whoami.example.com`. The site with be served [automatically over HTTPS](https://caddyserver.com/docs/automatic-https) with a certificate issued by Let's Encrypt or ZeroSSL.
 		
 ## Labels to Caddyfile conversion
-Any label prefixed with caddy, will be converted to caddyfile configuration following those rules:
+Please first read the [Caddyfile Concepts](https://caddyserver.com/docs/caddyfile/concepts) documentation to understand the structure of a Caddyfile.
 
-Keys are directive name and values are whitespace separated arguments:
+Any label prefixed with `caddy` will be converted into a Caddyfile config, following these rules:
+
+### Tokens and arguments
+
+Keys are the directive name, and values are whitespace separated arguments:
 ```
 caddy.directive: arg1 arg2
 ↓
@@ -110,7 +143,7 @@ World` 200
 }
 ```
 
-Dots represents nesting and grouping is done automatically:
+Dots represent nesting, and grouping is done automatically:
 ```
 caddy.directive: argA  
 caddy.directive.subdirA: valueA  
@@ -124,7 +157,7 @@ caddy.directive.subdirB: valueB1 valueB2
 }
 ```
 
-Labels for parent directives are optional:
+Arguments for the parent directive are optional (e.g. no arguments to `directive`, setting subdirective `subdirA` directly):
 ```
 caddy.directive.subdirA: valueA
 ↓
@@ -135,7 +168,7 @@ caddy.directive.subdirA: valueA
 }
 ```
 
-Labels with empty values generates directives without arguments:
+Labels with empty values generates a directive without any arguments:
 ```
 caddy.directive:
 ↓
@@ -144,7 +177,11 @@ caddy.directive:
 }
 ```
 
-Directives are ordered alphabetically by default:
+### Ordering and isolation
+
+Be aware that directives are subject to be sorted according to the default [directive order](https://caddyserver.com/docs/caddyfile/directives#directive-order) defined by Caddy, when the Caddyfile is parsed (after the Caddyfile is generated from labels).
+
+[Directives](https://caddyserver.com/docs/caddyfile/directives) from labels are ordered alphabetically by default:
 ```
 caddy.bbb: value
 caddy.aaa: value
@@ -157,20 +194,20 @@ caddy.aaa: value
 
 Suffix _&lt;number&gt; isolates directives that otherwise would be grouped:
 ```
-caddy.group_0.a: value
-caddy.group_1.b: value
+caddy.route_0.a: value
+caddy.route_1.b: value
 ↓
 {
-	group {
+	route {
 		a value
 	}
-	group {
+	route {
 		b value
 	}
 }
 ```
 
-Prefix &lt;number&gt;_ isolates directives but also defines a custom ordering for directives, and directives without order prefix will go last:
+Prefix &lt;number&gt;_ isolates directives but also defines a custom ordering for directives (mainly relevant within [`route`](https://caddyserver.com/docs/caddyfile/directives/route) blocks), and directives without order prefix will go last:
 ```
 caddy.1_bbb: value
 caddy.2_aaa: value
@@ -183,23 +220,25 @@ caddy.3_aaa: value
 }
 ```
 
-Caddy label args creates a server block:
+### Sites, snippets and global options
+
+A label `caddy` creates a [site block](https://caddyserver.com/docs/caddyfile/concepts):
 ```
 caddy: example.com
-caddy.respond: 200 /
+caddy.respond: "Hello World" 200
 ↓
 example.com {
-	respond 200 /
+	respond "Hello World" 200
 }
 ```
 
-Or a snippet:
+Or a [snippet](https://caddyserver.com/docs/caddyfile/concepts#snippets):
 ```
-caddy: (snippet)
-caddy.respond: 200 /
+caddy: (encode)
+caddy.encode: zstd gzip
 ↓
-(snippet) {
-	respond 200 /
+(encode) {
+	encode zstd gzip
 }
 ```
 
@@ -223,7 +262,16 @@ site_b {
 }
 ```
 
-Named matchers can be created using @ inside labels:
+[Global options](https://caddyserver.com/docs/caddyfile/options) can be defined by not setting any value for `caddy`. They can be set in any container/service, including caddy-docker-proxy itself. [Here is an example](examples/standalone.yaml#L19)
+```
+caddy.email: you@example.com
+↓
+{
+	email you@example.com
+}
+```
+
+[Named matchers](https://caddyserver.com/docs/caddyfile/matchers#named-matchers) can be created using `@` inside labels:
 ```
 caddy: localhost
 caddy.@match.path: /sourcepath /sourcepath/*
@@ -237,16 +285,9 @@ localhost {
 }
 ```
 
-Global options can be defined by not setting any value for caddy. It can be set in any container/service, including caddy-docker-proxy itself. [Here is an example](examples/standalone.yaml#L19)
-```
-caddy.email: you@example.com
-↓
-{
-	email you@example.com
-}
-```
+### Go templates
 
-[GoLang templates](https://golang.org/pkg/text/template/) can be used inside label values to increase flexibility. From templates you have access to current docker resource information. But keep in mind that the structure that describes a docker container is different from a service.
+[Golang templates](https://golang.org/pkg/text/template/) can be used inside label values to increase flexibility. From templates, you have access to current docker resource information. But, keep in mind that the structure that describes a docker container is different from a service.
 
 While you can access a service name like this:
 ```
@@ -310,54 +351,52 @@ reverse_proxy http://192.168.0.1:8080 http://192.168.0.2:8080
 ```
 
 ## Reverse proxy examples
-Proxying domain root to container root
-```
+Proxying all requests to a domain to the container
+```yml
 caddy: example.com
 caddy.reverse_proxy: {{upstreams}}
 ```
 
-Proxying domain root to container path
-```
+Proxying all requests to a domain to a subpath in the container
+```yml
 caddy: example.com
 caddy.rewrite: * /target{path}
 caddy.reverse_proxy: {{upstreams}}
 ```
 
-Proxying domain path to container root
-```
+Proxying requests matching a path, while stripping that path prefix
+```yml
 caddy: example.com
-caddy.route: /source/*
-caddy.route.0_uri: strip_prefix /source
-caddy.route.1_reverse_proxy: {{upstreams}}
+caddy.handle_path: /source/*
+caddy.handle_path.0_reverse_proxy: {{upstreams}}
 ```
 
-Proxying domain path to different container path
-```
+Proxying requests matching a path, rewriting to different path prefix
+```yml
 caddy: example.com
-caddy.route: /source/*
-caddy.route.0_uri: strip_prefix /source
-caddy.route.1_rewrite: * /target{path}
-caddy.route.2_reverse_proxy: {{upstreams}}
+caddy.handle_path: /source/*
+caddy.handle_path.0_rewrite: * /target{uri}
+caddy.handle_path.1_reverse_proxy: {{upstreams}}
 ```
 
-Proxying domain path to subpath
-```
+Proxying all websocket requests, and all requests to `/api*`, to the container
+```yml
 caddy: example.com
-caddy.route: /source/*
-caddy.route.0_uri: strip_prefix /source
-caddy.route.1_rewrite: * /source/target{path}
-caddy.route.2_reverse_proxy: {{upstreams}}
+caddy.@ws.0_header: Connection *Upgrade*
+caddy.@ws.1_header: Upgrade websocket
+caddy.0_reverse_proxy: @ws {{upstreams}}
+caddy.1_reverse_proxy: /api* {{upstreams}}
 ```
 
-Proxying multiple domains to container
-```
-caddy: example.com example.org
+Proxying multiple domains, with certificates for each
+```yml
+caddy: example.com, example.org, www.example.com, www.example.org
 caddy.reverse_proxy: {{upstreams}}
 ```
 
 ## Docker configs
 
-> Note: Docker Swarm only. Alternativly use `CADDY_DOCKER_CADDYFILE_PATH` or `-caddyfile-path`
+> Note: This is for Docker Swarm only. Alternativly, use `CADDY_DOCKER_CADDYFILE_PATH` or `-caddyfile-path`
 
 You can also add raw text to your caddyfile using docker configs. Just add caddy label prefix to your configs and the whole config content will be inserted at the beginning of the generated caddyfile, outside any server blocks.
 
@@ -367,26 +406,26 @@ You can also add raw text to your caddyfile using docker configs. Just add caddy
 Caddy docker proxy is able to proxy to swarm services or raw containers. Both features are always enabled, and what will differentiate the proxy target is where you define your labels.
 
 ### Services
-To proxy swarm services, labels should be defined at service level. On a docker-compose file, that means labels should be inside deploy, like:
-```
-service:
-	...
-	deploy:
-		labels:
-			caddy: service.example.com
-			caddy.reverse_proxy: {{upstreams}}
+To proxy swarm services, labels should be defined at service level. In a docker-compose file, labels should be _inside_ `deploy`, like:
+```yml
+services:
+  foo:
+    deploy:
+      labels:
+        caddy: service.example.com
+        caddy.reverse_proxy: {{upstreams}}
 ```
 
 Caddy will use service DNS name as target or all service tasks IPs, depending on configuration **proxy-service-tasks**.
 
 ### Containers
-To proxy containers, labels should be defined at container level. On a docker-compose file, that means labels should be outside deploy, like:
-```
-service:
-	...
-	labels:
-		caddy: service.example.com
-		caddy.reverse_proxy: {{upstreams}}
+To proxy containers, labels should be defined at container level. In a docker-compose file, labels should be _outside_ `deploy`, like:
+```yml
+services:
+  foo:
+    labels:
+      caddy: service.example.com
+      caddy.reverse_proxy: {{upstreams}}
 ```
 
 ## Execution modes
@@ -423,7 +462,7 @@ This mode executes a controller and a server in the same instance and doesn't re
 
 ## Caddy CLI
 
-This plugin extends caddy cli with command `caddy docker-proxy` and flags.
+This plugin extends caddy's CLI with the command `caddy docker-proxy`.
 
 Run `caddy help docker-proxy` to see all available flags.
 
@@ -480,9 +519,9 @@ But they're also quite hard to throubleshoot because they don't have shell or an
 The alpine images variant are based on Linux Alpine image, a very small Linux distribution with shell and basic utilities tools. Use `-alpine` images if you want to trade security and small size for better throubleshooting experience.
 
 ### CI images
-Images with `ci` on it's tag name means they was automatically generated by automated builds.
-CI images reflect the current state of master branch and they might be very broken sometimes.
-You should use CI images if you want to help testing latest features before they're officialy released.
+Images with the `ci` tag suffix means they were automatically generated by automated builds.
+CI images reflect the current state of master branch and their stability is not guaranteed.
+You may use CI images if you want to help testing the latest features before they're officialy released.
 
 ### ARM architecture images
 Currently we provide linux x86_64 images by default.
@@ -490,13 +529,33 @@ Currently we provide linux x86_64 images by default.
 You can also find images for other architectures like `arm32v6` images that can be used on Raspberry Pi.
 
 ### Windows images
-We recently introduced experimental windows containers images with suffix `nanoserver-1803`.
+We recently introduced experimental windows containers images with the tag suffix `nanoserver-1803`.
 
 Be aware that this needs to be tested further.
 
 This is an example of how to mount the windows docker pipe using CLI:
+```shell
+$ docker run --rm -it -v //./pipe/docker_engine://./pipe/docker_engine lucaslorentz/caddy-docker-proxy:ci-nanoserver-1803
 ```
-docker run --rm -it -v //./pipe/docker_engine://./pipe/docker_engine lucaslorentz/caddy-docker-proxy:ci-nanoserver-1803
+
+### Custom images
+If you need additional Caddy plugins, or need to use a specific version of Caddy, then you may use the `builder` variant of the [official Caddy docker image](https://hub.docker.com/_/caddy) to make your own `Dockerfile`.
+
+The main difference from the instructions on the official image, is that you must override `CMD` to have the container run using the `caddy docker-proxy` command provided by this plugin.
+
+```Dockerfile
+ARG CADDY_VERSION=2.4.0
+FROM caddy:${CADDY_VERSION}-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/lucaslorentz/caddy-docker-proxy/plugin/v2 \
+    --with <additional-plugins>
+
+FROM caddy:${CADDY_VERSION}-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+CMD ["caddy", "docker-proxy"]
 ```
 
 ## Connecting to Docker Host
@@ -524,45 +583,45 @@ Multiple Caddy instances automatically orchestrates certificate issuing between 
 
 ## Trying it
 
-### With compose file
+### With docker-compose file
 
 Clone this repository.
 
 Deploy the compose file to swarm cluster:
 ```
-docker stack deploy -c examples/standalone.yaml caddy-docker-demo
+$ docker stack deploy -c examples/standalone.yaml caddy-docker-demo
 ```
 
 Wait a bit for services startup...
 
 Now you can access each services/container using different urls
 ```
-curl -k --resolve whoami0.example.com:443:127.0.0.1 https://whoami0.example.com
-curl -k --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com
-curl -k --resolve whoami2.example.com:443:127.0.0.1 https://whoami2.example.com
-curl -k --resolve whoami3.example.com:443:127.0.0.1 https://whoami3.example.com
-curl -k --resolve config.example.com:443:127.0.0.1 https://config.example.com
-curl -k --resolve echo0.example.com:443:127.0.0.1 https://echo0.example.com/sourcepath/something
+$ curl -k --resolve whoami0.example.com:443:127.0.0.1 https://whoami0.example.com
+$ curl -k --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com
+$ curl -k --resolve whoami2.example.com:443:127.0.0.1 https://whoami2.example.com
+$ curl -k --resolve whoami3.example.com:443:127.0.0.1 https://whoami3.example.com
+$ curl -k --resolve config.example.com:443:127.0.0.1 https://config.example.com
+$ curl -k --resolve echo0.example.com:443:127.0.0.1 https://echo0.example.com/sourcepath/something
 ```
 
 After testing, delete the demo stack:
 ```
-docker stack rm caddy-docker-demo
+$ docker stack rm caddy-docker-demo
 ```
 
 ### With run commands
 
 ```
-docker run --name caddy -d -p 443:443 -v /var/run/docker.sock:/var/run/docker.sock lucaslorentz/caddy-docker-proxy:ci-alpine
+$ docker run --name caddy -d -p 443:443 -v /var/run/docker.sock:/var/run/docker.sock lucaslorentz/caddy-docker-proxy:ci-alpine
 
-docker run --name whoami0 -d -l caddy=whoami0.example.com -l "caddy.reverse_proxy={{upstreams 8000}}" -l caddy.tls=internal jwilder/whoami
+$ docker run --name whoami0 -d -l caddy=whoami0.example.com -l "caddy.reverse_proxy={{upstreams 8000}}" -l caddy.tls=internal jwilder/whoami
 
-docker run --name whoami1 -d -l caddy=whoami1.example.com -l "caddy.reverse_proxy={{upstreams 8000}}" -l caddy.tls=internal jwilder/whoami
+$ docker run --name whoami1 -d -l caddy=whoami1.example.com -l "caddy.reverse_proxy={{upstreams 8000}}" -l caddy.tls=internal jwilder/whoami
 
-curl -k --resolve whoami0.example.com:443:127.0.0.1 https://whoami0.example.com
-curl -k --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com
+$ curl -k --resolve whoami0.example.com:443:127.0.0.1 https://whoami0.example.com
+$ curl -k --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com
 
-docker rm -f caddy whoami0 whoami1
+$ docker rm -f caddy whoami0 whoami1
 ```
 
 ## Building it


### PR DESCRIPTION
- Add more headers for the label to Caddyfile conversion section, to make it easier to link to with anchors
- Add TOC (just used a tool to generate it to start)
- Add language hints on code blocks
- Prefix commands with `$`
- Clean up some examples
- Adjust some English
- Add `Dockerfile` example for building with additional plugins
- Remove the "Caddy v2" note at the top because Caddy v1 is EOL at this point