### PR TITLE
Fix caddy hanging with empty config when unable to establish connection with docker during startup

### DIFF
--- a/plugin/cmd.go
+++ b/plugin/cmd.go
@@ -66,17 +66,26 @@ func cmdFunc(flags caddycmd.Flags) (int, error) {
 	if options.Mode&config.Server == config.Server {
 		log.Info("Running caddy proxy server")
 
-		caddy.Run(&caddy.Config{
+		err := caddy.Run(&caddy.Config{
 			Admin: &caddy.AdminConfig{
 				Listen: getAdminListen(options),
 			},
 		})
+		if err != nil {
+			return 1, err
+		}
 	}
 
 	if options.Mode&config.Controller == config.Controller {
 		log.Info("Running caddy proxy controller")
 		loader := CreateDockerLoader(options)
-		loader.Start()
+		if err := loader.Start(); err != nil {
+			if err := caddy.Stop(); err != nil {
+				return 1, err
+			}
+
+			return 1, err
+		}
 	}
 
 	select {}


### PR DESCRIPTION
I have a swarm deploy that uses [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) for proxying all communication to the docker socket. Sometimes, when doing a full swarm re-deploy, my caddy containers would not apply the configuration specified in the docker labels, and would stay up with empty configurations, and the following error log:

```
{"level":"info","ts":1624826623.0097046,"logger":"docker-proxy","msg":"Running caddy proxy controller"}
{"level":"error","ts":1624826624.392478,"logger":"docker-proxy","msg":"Docker ping failed","error":"error during connect: Get \"http://docker_proxy:2375/_ping\": dial tcp: lookup docker_proxy on 127.0.0.11:53: no such host","errorVerbose":"Get \"http://docker_proxy:2375/_ping\": dial tcp: lookup docker_proxy on 127.0.0.11:53: no such host\nerror during connect\ngithub.com/docker/docker/client.(*Client).doRequest\n\tgithub.com/docker/docker@v20.10.6+incompatible/client/request.go:180\ngithub.com/docker/docker/client.(*Client).Ping\n\tgithub.com/docker/docker@v20.10.6+incompatible/client/ping.go:42\ngithub.com/lucaslorentz/caddy-docker-proxy/plugin/v2.(*DockerLoader).Start\n\tgithub.com/lucaslorentz/caddy-docker-proxy/plugin/v2@v2.0.0-00010101000000-000000000000/loader.go:66\ngithub.com/lucaslorentz/caddy-docker-proxy/plugin/v2.cmdFunc\n\tgithub.com/lucaslorentz/caddy-docker-proxy/plugin/v2@v2.0.0-00010101000000-000000000000/cmd.go:82\ngithub.com/caddyserver/caddy/v2/cmd.Main\n\tgithub.com/caddyserver/caddy/v2@v2.4.3/cmd/main.go:85\nmain.main\n\tcaddy/main.go:13\nruntime.main\n\truntime/proc.go:225\nruntime.goexit\n\truntime/asm_amd64.s:1371"}
```

I realized this always happened whenever the caddy container would start before the docker-socket-proxy one.

Checking the code, I found that there were some error checks missing in [`cmdFunc`](https://github.com/lucaslorentz/caddy-docker-proxy/blob/264ae8a29163c416e544547039d6efbc2a83872a/plugin/cmd.go#L60-L83), which resulted in the process staying up even when [`caddy.Run`](https://github.com/lucaslorentz/caddy-docker-proxy/blob/264ae8a29163c416e544547039d6efbc2a83872a/plugin/cmd.go#L69-L73) or [`loader.Start`](https://github.com/lucaslorentz/caddy-docker-proxy/blob/264ae8a29163c416e544547039d6efbc2a83872a/plugin/cmd.go#L79) failed to execute. My changes add those error checks, and return early to ensure the process exit cleanly whenever it encounter errors during startup.

This should also fix the issue: https://github.com/lucaslorentz/caddy-docker-proxy/issues/200