### PR TITLE
Added support for h2c protocol to upstreams

### DIFF
--- a/plugin/generator/labels.go
+++ b/plugin/generator/labels.go
@@ -33,6 +33,9 @@ func labelsToCaddyfile(labels map[string]string, templateData interface{}, getTa
 		"https": func() string {
 			return "https"
 		},
+		"h2c": func() string {
+			return "h2c"
+		},
 	}
 
 	return caddyfile.FromLabels(labels, templateData, funcMap)

--- a/plugin/generator/testdata/labels/h2c_reverse_proxy.txt
+++ b/plugin/generator/testdata/labels/h2c_reverse_proxy.txt
@@ -1,0 +1,6 @@
+caddy               = service.testdomain.com
+caddy.reverse_proxy = {{upstreams h2c 5000}}
+----------
+service.testdomain.com {
+	reverse_proxy h2c://target:5000
+}


### PR DESCRIPTION
Currently the only protocols that are supported by this plugin are
`http` and `https` but Caddy itself does have support for `h2c` as well.