### PR TITLE
Add new test for wildcard certificates, fix `health_path` warning

### DIFF
--- a/plugin/caddyfile/testdata/labels/wildcard_certificates.txt
+++ b/plugin/caddyfile/testdata/labels/wildcard_certificates.txt
@@ -1,0 +1,20 @@
+caddy = *.example.com
+caddy.1_@foo = host foo.example.com
+caddy.1_handle = @foo
+caddy.1_handle.reverse_proxy = foo:8080
+
+caddy = *.example.com
+caddy.2_@bar = host bar.example.com
+caddy.2_handle = @bar
+caddy.2_handle.reverse_proxy = bar:8080
+----------
+*.example.com {
+	@foo host foo.example.com
+	@bar host bar.example.com
+	handle @foo {
+		reverse_proxy foo:8080
+	}
+	handle @bar {
+		reverse_proxy bar:8080
+	}
+}

--- a/plugin/caddyfile/testdata/marshal/marshal.txt
+++ b/plugin/caddyfile/testdata/marshal/marshal.txt
@@ -8,7 +8,7 @@ service2.example.com {
 	respond 200 /
 	route * {
 		reverse_proxy service2:5000 {
-			health_path /health
+			health_uri /health
 		}
 	}
 	encode gzip
@@ -34,7 +34,7 @@ service2.example.com {
 	respond 200 /
 	route * {
 		reverse_proxy service2:5000 {
-			health_path /health
+			health_uri /health
 		}
 	}
 	encode gzip

--- a/plugin/caddyfile/testdata/process/invalid_block.txt
+++ b/plugin/caddyfile/testdata/process/invalid_block.txt
@@ -13,7 +13,7 @@ service2.example.com {
 	respond 200 /
 	# Comment
 	reverse_proxy service2:5000 {
-		health_path /health
+		health_uri /health
 	}
 	import mysnippet
 }
@@ -36,7 +36,7 @@ service3.example.com {
 service2.example.com {
 	respond 200 /
 	reverse_proxy service2:5000 {
-		health_path /health
+		health_uri /health
 	}
 	import mysnippet
 }

--- a/plugin/generator/containers_test.go
+++ b/plugin/generator/containers_test.go
@@ -236,13 +236,13 @@ func TestContainers_ComplexMerge(t *testing.T) {
 				},
 			},
 			Labels: map[string]string{
-				fmtLabel("%s"):                                 "service.testdomain.com",
-				fmtLabel("%s.route"):                           "/a/*",
-				fmtLabel("%s.route.0_uri"):                     "strip_prefix /a",
-				fmtLabel("%s.route.reverse_proxy"):             "{{upstreams}}",
-				fmtLabel("%s.route.reverse_proxy.health_path"): "/health",
-				fmtLabel("%s.redir"):                           "/a /a1",
-				fmtLabel("%s.tls"):                             "internal",
+				fmtLabel("%s"):                                "service.testdomain.com",
+				fmtLabel("%s.route"):                          "/a/*",
+				fmtLabel("%s.route.0_uri"):                    "strip_prefix /a",
+				fmtLabel("%s.route.reverse_proxy"):            "{{upstreams}}",
+				fmtLabel("%s.route.reverse_proxy.health_uri"): "/health",
+				fmtLabel("%s.redir"):                          "/a /a1",
+				fmtLabel("%s.tls"):                            "internal",
 			},
 		},
 		{
@@ -255,13 +255,13 @@ func TestContainers_ComplexMerge(t *testing.T) {
 				},
 			},
 			Labels: map[string]string{
-				fmtLabel("%s"):                                 "service.testdomain.com",
-				fmtLabel("%s.route"):                           "/b/*",
-				fmtLabel("%s.route.0_uri"):                     "strip_prefix /b",
-				fmtLabel("%s.route.reverse_proxy"):             "{{upstreams}}",
-				fmtLabel("%s.route.reverse_proxy.health_path"): "/health",
-				fmtLabel("%s.redir"):                           "/b /b1",
-				fmtLabel("%s.tls"):                             "internal",
+				fmtLabel("%s"):                                "service.testdomain.com",
+				fmtLabel("%s.route"):                          "/b/*",
+				fmtLabel("%s.route.0_uri"):                    "strip_prefix /b",
+				fmtLabel("%s.route.reverse_proxy"):            "{{upstreams}}",
+				fmtLabel("%s.route.reverse_proxy.health_uri"): "/health",
+				fmtLabel("%s.redir"):                          "/b /b1",
+				fmtLabel("%s.tls"):                            "internal",
 			},
 		},
 	}
@@ -272,13 +272,13 @@ func TestContainers_ComplexMerge(t *testing.T) {
 		"	route /a/* {\n" +
 		"		uri strip_prefix /a\n" +
 		"		reverse_proxy 172.17.0.2 {\n" +
-		"			health_path /health\n" +
+		"			health_uri /health\n" +
 		"		}\n" +
 		"	}\n" +
 		"	route /b/* {\n" +
 		"		uri strip_prefix /b\n" +
 		"		reverse_proxy 172.17.0.3 {\n" +
-		"			health_path /health\n" +
+		"			health_uri /health\n" +
 		"		}\n" +
 		"	}\n" +
 		"	tls internal\n" +

--- a/plugin/generator/services_test.go
+++ b/plugin/generator/services_test.go
@@ -16,17 +16,17 @@ func TestServices_TemplateData(t *testing.T) {
 				Annotations: swarm.Annotations{
 					Name: "service",
 					Labels: map[string]string{
-						fmtLabel("%s"):                           "{{.Spec.Name}}.testdomain.com",
-						fmtLabel("%s.reverse_proxy"):             "{{.Spec.Name}}:5000",
-						fmtLabel("%s.reverse_proxy.health_path"): "/health",
-						fmtLabel("%s.gzip"):                      "",
-						fmtLabel("%s.basicauth"):                 "/ user password",
-						fmtLabel("%s.tls.dns"):                   "route53",
-						fmtLabel("%s.rewrite_0"):                 "/path1 /path2",
-						fmtLabel("%s.rewrite_1"):                 "/path3 /path4",
-						fmtLabel("%s.limits.header"):             "100kb",
-						fmtLabel("%s.limits.body_0"):             "/path1 2mb",
-						fmtLabel("%s.limits.body_1"):             "/path2 4mb",
+						fmtLabel("%s"):                          "{{.Spec.Name}}.testdomain.com",
+						fmtLabel("%s.reverse_proxy"):            "{{.Spec.Name}}:5000",
+						fmtLabel("%s.reverse_proxy.health_uri"): "/health",
+						fmtLabel("%s.gzip"):                     "",
+						fmtLabel("%s.basicauth"):                "/ user password",
+						fmtLabel("%s.tls.dns"):                  "route53",
+						fmtLabel("%s.rewrite_0"):                "/path1 /path2",
+						fmtLabel("%s.rewrite_1"):                "/path3 /path4",
+						fmtLabel("%s.limits.header"):            "100kb",
+						fmtLabel("%s.limits.body_0"):            "/path1 2mb",
+						fmtLabel("%s.limits.body_1"):            "/path2 4mb",
 					},
 				},
 			},
@@ -49,7 +49,7 @@ func TestServices_TemplateData(t *testing.T) {
 		"		header 100kb\n" +
 		"	}\n" +
 		"	reverse_proxy service:5000 {\n" +
-		"		health_path /health\n" +
+		"		health_uri /health\n" +
 		"	}\n" +
 		"	rewrite /path1 /path2\n" +
 		"	rewrite /path3 /path4\n" +

--- a/plugin/generator/testdata/labels/reverse_proxy_directives_are_moved_into_route.txt
+++ b/plugin/generator/testdata/labels/reverse_proxy_directives_are_moved_into_route.txt
@@ -1,14 +1,14 @@
-caddy                                   = service.testdomain.com
-caddy.route                             = /path/*
-caddy.route.0_uri                       = strip_prefix /path
-caddy.route.1_reverse_proxy             = {{upstreams}}
-caddy.route.1_reverse_proxy.health_path = /health
+caddy                                  = service.testdomain.com
+caddy.route                            = /path/*
+caddy.route.0_uri                      = strip_prefix /path
+caddy.route.1_reverse_proxy            = {{upstreams}}
+caddy.route.1_reverse_proxy.health_uri = /health
 ----------
 service.testdomain.com {
 	route /path/* {
 		uri strip_prefix /path
 		reverse_proxy target {
-			health_path /health
+			health_uri /health
 		}
 	}
 }


### PR DESCRIPTION
- Added a test that I quickly wrote for https://github.com/lucaslorentz/caddy-docker-proxy/issues/304 to make sure merging for wildcard certificates should work properly

- The `health_path` option is deprecated, should now use `health_uri`, as of 2.4.0 https://github.com/caddyserver/caddy/releases/tag/v2.4.0