### PR TITLE
Fix race condition in DockerLoader.Start()

### DIFF
--- a/plugin/loader.go
+++ b/plugin/loader.go
@@ -90,9 +90,12 @@ func (dockerLoader *DockerLoader) Start() error {
 			zap.String("IngressNetworks", fmt.Sprintf("%v", dockerLoader.options.IngressNetworks)),
 		)
 
+		ready := make(chan struct{})
 		dockerLoader.timer = time.AfterFunc(0, func() {
+			<-ready
 			dockerLoader.update()
 		})
+		close(ready)
 
 		go dockerLoader.monitorEvents()
 	}


### PR DESCRIPTION
dockerLoader.timer is used in dockerLoader.update() but may still be nil
when dockerLoader.update() is first called by the timer.

Fixes: https://github.com/lucaslorentz/caddy-docker-proxy/issues/306