### PR TITLE
Change Caddyfile path not set and Swarm not available logs to Debug

### DIFF
--- a/plugin/generator/containers_test.go
+++ b/plugin/generator/containers_test.go
@@ -34,7 +34,7 @@ func TestContainers_TemplateData(t *testing.T) {
 		"	reverse_proxy 172.17.0.2:5000/api\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -66,7 +66,7 @@ func TestContainers_PicksRightNetwork(t *testing.T) {
 		"	reverse_proxy 172.17.0.2\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -95,7 +95,7 @@ func TestContainers_DifferentNetwork(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	const expectedLogs = commonLogs +
 		`WARN	Container is not in same network as caddy	{"container": "CONTAINER-ID", "container id": "CONTAINER-ID"}` + newLine
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
@@ -131,7 +131,7 @@ func TestContainers_ManualIngressNetworks(t *testing.T) {
 		"	reverse_proxy 10.0.0.1\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog
+	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -175,7 +175,7 @@ func TestContainers_Replicas(t *testing.T) {
 		"	reverse_proxy 172.17.0.2 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -218,7 +218,7 @@ func TestContainers_DoNotMergeDifferentProxies(t *testing.T) {
 		"	reverse_proxy /b/* 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -284,7 +284,7 @@ func TestContainers_ComplexMerge(t *testing.T) {
 		"	tls internal\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -336,7 +336,7 @@ func TestContainers_WithSnippets(t *testing.T) {
 		"	reverse_proxy 172.17.0.3\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -82,7 +82,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 			}
 		}
 	} else {
-		logger.Info("Skipping default Caddyfile because no path is set")
+		logger.Debug("Skipping default Caddyfile because no path is set")
 	}
 
 	for i, dockerClient := range(g.dockerClients){
@@ -111,7 +111,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 				logger.Error("Failed to get Swarm configs", zap.Error(err))
 			}
 		} else {
-			logger.Info("Skipping swarm config caddyfiles because swarm is not available")
+			logger.Debug("Skipping swarm config caddyfiles because swarm is not available")
 		}
 	
 		// Add containers

--- a/plugin/generator/generator_test.go
+++ b/plugin/generator/generator_test.go
@@ -27,7 +27,6 @@ const ingressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[network-i
 const otherIngressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[other-network-id:true]"}` + newLine
 const swarmIsAvailableLog = `INFO	Swarm is available	{"new": true}` + newLine
 const swarmIsDisabledLog = `INFO	Swarm is available	{"new": false}` + newLine
-const skipCaddyfileLog = "INFO	Skipping default Caddyfile because no path is set" + newLine
 const commonLogs = containerIdLog + ingressNetworksMapLog + swarmIsAvailableLog
 
 func init() {
@@ -89,7 +88,7 @@ func TestMergeConfigContent(t *testing.T) {
 		"	reverse_proxy 127.0.0.1 172.17.0.2\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -121,7 +120,7 @@ func TestIgnoreLabelsWithoutCaddyPrefix(t *testing.T) {
 
 	const expectedCaddyfile = "# Empty caddyfile"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }

--- a/plugin/generator/services_test.go
+++ b/plugin/generator/services_test.go
@@ -58,7 +58,7 @@ func TestServices_TemplateData(t *testing.T) {
 		"	}\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -91,7 +91,7 @@ func TestServices_DifferentNetwork(t *testing.T) {
 		"	reverse_proxy service\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	const expectedLogs = commonLogs +
 		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICE-ID"}` + newLine
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
@@ -131,7 +131,7 @@ func TestServices_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy service\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog
+	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -169,8 +169,7 @@ func TestServices_SwarmDisabled(t *testing.T) {
 
 	const expectedCaddyfile = "# Empty caddyfile"
 
-	const expectedLogs = containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog + skipCaddyfileLog +
-		"INFO	Skipping swarm config caddyfiles because swarm is not available\n" +
+	const expectedLogs = containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog +
 		"INFO	Skipping swarm services because swarm is not available\n"
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
@@ -204,7 +203,7 @@ func TestServiceTasks_Empty(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	const expectedLogs = commonLogs +
 		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
@@ -268,7 +267,7 @@ func TestServiceTasks_NotRunning(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	const expectedLogs = commonLogs +
 		`WARN	Service has no tasks in running state	{"service": "service", "serviceId": "SERVICEID"}` + newLine
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
@@ -319,7 +318,7 @@ func TestServiceTasks_DifferentNetwork(t *testing.T) {
 		"	reverse_proxy\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog +
+	const expectedLogs = commonLogs +
 		`WARN	Service is not in same network as caddy	{"service": "service", "serviceId": "SERVICEID"}` + newLine
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
@@ -376,7 +375,7 @@ func TestServiceTasks_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog + skipCaddyfileLog
+	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -440,7 +439,7 @@ func TestServiceTasks_Running(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000 10.0.0.2:5000\n" +
 		"}\n"
 
-	const expectedLogs = commonLogs + skipCaddyfileLog
+	const expectedLogs = commonLogs
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true


### PR DESCRIPTION
Hi there!

First, thanks a lot for this project, it is very useful!

When running `caddy-docker-proxy` without a Caddyfile or Swarm mode enabled, the log messages below are emitted every polling interval (default for 30s).

```
caddy_1  | {"level":"info","ts":1645116020.518531,"logger":"docker-proxy","msg":"Skipping swarm services because swarm is not available"}
caddy_1  | {"level":"info","ts":1645116050.5464995,"logger":"docker-proxy","msg":"Skipping default Caddyfile because no path is set"}
caddy_1  | {"level":"info","ts":1645116050.54652,"logger":"docker-proxy","msg":"Skipping swarm config caddyfiles because swarm is not available"}
caddy_1  | {"level":"info","ts":1645116050.5493286,"logger":"docker-proxy","msg":"Skipping swarm services because swarm is not available"}
caddy_1  | {"level":"info","ts":1645116080.5410242,"logger":"docker-proxy","msg":"Skipping default Caddyfile because no path is set"}
...
```

This can be too verbose when running without a Caddyfile or Swarm. This PR changes these two log messages from `Info` to `Debug`. 

I believe it offers a better user experience by avoiding emitting unnecessary logs.