### PR TITLE
Add ability to not send scopes as a filter with event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ CADDY_DOCKER_MODE=<string>
 CADDY_DOCKER_POLLING_INTERVAL=<duration>
 CADDY_DOCKER_PROCESS_CADDYFILE=<bool>
 CADDY_DOCKER_PROXY_SERVICE_TASKS=<bool>
+DOCKER_NO_SCOPE=<bool, default scope used>
 ```
 
 Check **examples** folder to see how to set them on a Docker Compose file.

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ CADDY_DOCKER_MODE=<string>
 CADDY_DOCKER_POLLING_INTERVAL=<duration>
 CADDY_DOCKER_PROCESS_CADDYFILE=<bool>
 CADDY_DOCKER_PROXY_SERVICE_TASKS=<bool>
-DOCKER_NO_SCOPE=<bool, default scope used>
+CADDY_DOCKER_NO_SCOPE=<bool, default scope used>
 ```
 
 Check **examples** folder to see how to set them on a Docker Compose file.

--- a/loader.go
+++ b/loader.go
@@ -168,7 +168,7 @@ func (dockerLoader *DockerLoader) monitorEvents() {
 
 func (dockerLoader *DockerLoader) listenEvents() {
 	args := filters.NewArgs()
-	if !isTrue.MatchString(os.Getenv("DOCKER_NO_SCOPE")) {
+	if !isTrue.MatchString(os.Getenv("CADDY_DOCKER_NO_SCOPE")) {
 		// This env var is useful for Podman where in some instances the scope can cause some issues.
 		args.Add("scope", "swarm")
 		args.Add("scope", "local")

--- a/loader.go
+++ b/loader.go
@@ -168,8 +168,11 @@ func (dockerLoader *DockerLoader) monitorEvents() {
 
 func (dockerLoader *DockerLoader) listenEvents() {
 	args := filters.NewArgs()
-	args.Add("scope", "swarm")
-	args.Add("scope", "local")
+	if !isTrue.MatchString(os.Getenv("DOCKER_NO_SCOPE")) {
+		// This env var is useful for Podman where in some instances the scope can cause some issues.
+		args.Add("scope", "swarm")
+		args.Add("scope", "local")
+	}
 	args.Add("type", "service")
 	args.Add("type", "container")
 	args.Add("type", "config")


### PR DESCRIPTION
Unfortunately, doing so in Podman will sometimes lead to an EOF, causing the proxy to stop consuming events. This solves that issue with Podman compatibility.