### PR TITLE
Improve logic to find self container id

### DIFF
--- a/docker/utils.go
+++ b/docker/utils.go
@@ -1,8 +1,6 @@
 package docker
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -23,29 +21,54 @@ func CreateUtils() Utils {
 
 // GetCurrentContainerID returns the id of the container running this application
 func (wrapper *dockerUtils) GetCurrentContainerID() (string, error) {
-	if runtime.GOOS == "windows" {
-		return os.Hostname()
+	var containerID string
+	var err error
+	if runtime.GOOS == "linux" {
+		if containerID == "" && err == nil {
+			containerID, err = wrapper.getCurrentContainerIDFromCGroup()
+		}
+		if containerID == "" && err == nil {
+			containerID, err = wrapper.getCurrentContainerIDFromMountInfo()
+		}
 	}
+	if containerID == "" && err == nil {
+		containerID, err = os.Hostname()
+	}
+	return containerID, err
+}
 
+func (wrapper *dockerUtils) getCurrentContainerIDFromMountInfo() (string, error) {
+	bytes, err := ioutil.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return "", err
+	}
+	containerID := wrapper.extractContainerIDFromMountInfo(string(bytes))
+	return containerID, nil
+}
+
+func (wrapper *dockerUtils) getCurrentContainerIDFromCGroup() (string, error) {
 	bytes, err := ioutil.ReadFile("/proc/self/cgroup")
 	if err != nil {
 		return "", err
 	}
-	if len(bytes) == 0 {
-		return "", errors.New("Cannot read /proc/self/cgroup")
-	}
-
-	return wrapper.ExtractContainerID(string(bytes))
-
+	containerID := wrapper.extractContainerIDFromCGroups(string(bytes))
+	return containerID, nil
 }
 
-func (wrapper *dockerUtils) ExtractContainerID(cgroups string) (string, error) {
+func (wrapper *dockerUtils) extractContainerIDFromMountInfo(cgroups string) string {
+	idRegex := regexp.MustCompile(`containers/([[:alnum:]]{64})/`)
+	matches := idRegex.FindStringSubmatch(cgroups)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[len(matches)-1]
+}
+
+func (wrapper *dockerUtils) extractContainerIDFromCGroups(cgroups string) string {
 	idRegex := regexp.MustCompile(`(?im)^[^:]*:[^:]*:.*\b([[:alnum:]]{64})\b`)
 	matches := idRegex.FindStringSubmatch(cgroups)
-
 	if len(matches) == 0 {
-		return "", fmt.Errorf("Cannot find container id in cgroups: %v", cgroups)
+		return ""
 	}
-
-	return matches[len(matches)-1], nil
+	return matches[len(matches)-1]
 }


### PR DESCRIPTION
Use mountinfo, fallback to cgroups, fallback to hostname.
Fixes #207