### PR TITLE
Update to use alpine 3.17 instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} alpine:3.15.4 as alpine
+FROM --platform=${BUILDPLATFORM} alpine:3.17.0 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 # Image starts here

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4 as alpine
+FROM alpine:3.17.0 as alpine
 ARG TARGETPLATFORM
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 


### PR DESCRIPTION
Current 3.15.4 image is flagged for CVE-2022-37434 per trivy scan