### PR TITLE
Per container ingress network override

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ For containers, that would be the container IPs.
 
 Only containers/services that are connected to Caddy ingress networks are used.
 
-:warning: caddy docker proxy does a best effort to automatically detect what are the ingress networks. But that logic fails on some scenarios: [#207](https://github.com/lucaslorentz/caddy-docker-proxy/issues/207). To have a more resilient solution, you can manually configure Caddy ingress network using CLI option `ingress-networks` or environment variable `CADDY_INGRESS_NETWORKS`.
+:warning: caddy docker proxy does a best effort to automatically detect what are the ingress networks. But that logic fails on some scenarios: [#207](https://github.com/lucaslorentz/caddy-docker-proxy/issues/207). To have a more resilient solution, you can manually configure Caddy ingress network using CLI option `ingress-networks`, environment variable `CADDY_INGRESS_NETWORKS` or label `caddy_ingress_network`.
 
 Usage: `upstreams [http|https] [port]`  
 

--- a/generator/containers.go
+++ b/generator/containers.go
@@ -14,7 +14,7 @@ func (g *CaddyfileGenerator) getContainerCaddyfile(container *types.Container, l
 	})
 }
 
-func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container, logger *zap.Logger, ingress bool) ([]string, error) {
+func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container, logger *zap.Logger, onlyIngressIps bool) ([]string, error) {
 	ips := []string{}
 
 	ingressNetworkFromLabel, overrideNetwork := container.Labels[IngressNetworkLabel]
@@ -22,10 +22,12 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container,
 	for networkName, network := range container.NetworkSettings.Networks {
 		include := false
 
-		if overrideNetwork {
+		if !onlyIngressIps  {
+			include = true
+		} else if overrideNetwork {
 			include = networkName == ingressNetworkFromLabel
 		} else {
-			include = !ingress || g.ingressNetworks[network.NetworkID]
+			include = g.ingressNetworks[network.NetworkID]
 		}
 
 		if include {

--- a/generator/containers_test.go
+++ b/generator/containers_test.go
@@ -145,6 +145,10 @@ func TestContainers_OverrideIngressNetworks(t *testing.T) {
 			ID:   "other-network-id",
 			Name: "other-network-name",
 		},
+		{
+			ID:   "another-network-id",
+			Name: "another-network-name",
+		},
 	}
 	dockerClient.ContainersData = []types.Container{
 		{
@@ -155,10 +159,14 @@ func TestContainers_OverrideIngressNetworks(t *testing.T) {
 						IPAddress: "10.0.0.1",
 						NetworkID: "other-network-id",
 					},
+					"another-network": {
+						IPAddress: "10.0.0.2",
+						NetworkID: "other-network-id",
+					},
 				},
 			},
 			Labels: map[string]string{
-				"caddy_ingress_network":      "other-network",
+				"caddy_ingress_network":      "another-network",
 				fmtLabel("%s"):               "service.testdomain.com",
 				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
 			},
@@ -166,12 +174,14 @@ func TestContainers_OverrideIngressNetworks(t *testing.T) {
 	}
 
 	const expectedCaddyfile = "service.testdomain.com {\n" +
-		"	reverse_proxy 10.0.0.1\n" +
+		"	reverse_proxy 10.0.0.2\n" +
 		"}\n"
 
 	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
 
-	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
+	testGeneration(t, dockerClient, func(options *config.Options) {
+		options.IngressNetworks = []string{"other-network-name"}
+	}, expectedCaddyfile, expectedLogs)
 }
 
 func TestContainers_Replicas(t *testing.T) {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -21,6 +21,8 @@ import (
 // DefaultLabelPrefix for caddy labels in docker
 const DefaultLabelPrefix = "caddy"
 
+const IngressNetworkLabel = "caddy_ingress_network"
+
 const swarmAvailabilityCacheInterval = 1 * time.Minute
 
 // CaddyfileGenerator generates caddyfile from docker configuration

--- a/generator/services.go
+++ b/generator/services.go
@@ -66,7 +66,7 @@ func (g *CaddyfileGenerator) getServiceTasksIps(service *swarm.Service, logger *
 		for _, task := range tasks {
 			if task.Status.State == swarm.TaskStateRunning {
 				hasRunningTasks = true
-				ingressNetworkFromLabel, overrideNetwork := task.Labels[IngressNetworkLabel]
+				ingressNetworkFromLabel, overrideNetwork := service.Spec.Labels[IngressNetworkLabel]
 
 				for _, networkAttachment := range task.NetworksAttachments {
 					include := false

--- a/generator/services_test.go
+++ b/generator/services_test.go
@@ -145,6 +145,10 @@ func TestServices_OverrideIngressNetwork(t *testing.T) {
 			ID:   "other-network-id",
 			Name: "other-network-name",
 		},
+		{
+			ID:   "another-network-id",
+			Name: "another-network-name",
+		},
 	}
 	dockerClient.ServicesData = []swarm.Service{
 		{
@@ -153,7 +157,7 @@ func TestServices_OverrideIngressNetwork(t *testing.T) {
 				Annotations: swarm.Annotations{
 					Name: "service",
 					Labels: map[string]string{
-						"caddy_ingress_network":      "other-network",
+						"caddy_ingress_network":      "another-network",
 						fmtLabel("%s"):               "service.testdomain.com",
 						fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
 					},
@@ -175,7 +179,9 @@ func TestServices_OverrideIngressNetwork(t *testing.T) {
 
 	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
 
-	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
+	testGeneration(t, dockerClient, func(options *config.Options) {
+		options.IngressNetworks = []string{"other-network-name"}
+	}, expectedCaddyfile, expectedLogs)
 }
 
 func TestServices_SwarmDisabled(t *testing.T) {

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -2,8 +2,8 @@
 
 function retry {
   local n=0
-  local max=5
-  local delay=20
+  local max=20
+  local delay=5
   while true; do
     ((n=n+1))
     "$@" && break || {

--- a/tests/ingress-networks/compose.yaml
+++ b/tests/ingress-networks/compose.yaml
@@ -11,6 +11,7 @@ services:
       - controller
       - ingress_0
       - ingress_1
+      - ingress_2
     environment:
       - CADDY_DOCKER_MODE=server
       - CADDY_CONTROLLER_NETWORK=10.200.200.0/24
@@ -54,11 +55,29 @@ services:
         caddy.reverse_proxy: "{{upstreams 80}}"
         caddy.tls: "internal"
 
+  # Proxy to service
+  whoami2:
+    image: containous/whoami
+    networks:
+      - internal
+      - ingress_2
+    deploy:
+      labels:
+        caddy: whoami2.example.com
+        caddy.reverse_proxy: "{{upstreams 80}}"
+        caddy.tls: "internal"
+        caddy_ingress_network: ingress_2
+
 networks:
   ingress_0:
     name: ingress_0
   ingress_1:
     name: ingress_1
+  ingress_2:
+    name: ingress_2
+  internal:
+    name: internal
+    internal: true
   controller:
     driver: overlay
     ipam:

--- a/tests/ingress-networks/run.sh
+++ b/tests/ingress-networks/run.sh
@@ -7,7 +7,8 @@ set -e
 docker stack deploy -c compose.yaml --prune caddy_test
 
 retry curl --show-error -s -k -f --resolve whoami0.example.com:443:127.0.0.1 https://whoami0.example.com &&
-retry curl --show-error -s -k -f --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com || {
+retry curl --show-error -s -k -f --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com &&
+retry curl --show-error -s -k -f --resolve whoami2.example.com:443:127.0.0.1 https://whoami2.example.com || {
     docker service logs caddy_test_caddy_controller
     docker service logs caddy_test_caddy_server
     exit 1

--- a/tests/standalone/compose.yaml
+++ b/tests/standalone/compose.yaml
@@ -56,6 +56,18 @@ services:
       caddy.reverse_proxy: "{{upstreams 80}}"
       caddy.tls: "internal"
 
+  # Proxy to container
+  whoami4:
+    image: containous/whoami
+    networks:
+      - internal
+      - caddy
+    labels:
+      caddy: whoami4.example.com
+      caddy.reverse_proxy: "{{upstreams 80}}"
+      caddy.tls: "internal"
+      caddy_ingress_network: caddy_test
+
   # Proxy with matches and route
   echo_0:
     image: containous/whoami
@@ -75,3 +87,6 @@ networks:
   caddy:
     name: caddy_test
     external: true
+  internal:
+    name: internal
+    internal: true

--- a/tests/standalone/run.sh
+++ b/tests/standalone/run.sh
@@ -10,6 +10,7 @@ retry curl --show-error -s -k -f --resolve whoami0.example.com:443:127.0.0.1 htt
 retry curl --show-error -s -k -f --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com &&
 retry curl --show-error -s -k -f --resolve whoami2.example.com:443:127.0.0.1 https://whoami2.example.com &&
 retry curl --show-error -s -k -f --resolve whoami3.example.com:443:127.0.0.1 https://whoami3.example.com &&
+retry curl --show-error -s -k -f --resolve whoami4.example.com:443:127.0.0.1 https://whoami4.example.com &&
 retry curl --show-error -s -k -f --resolve echo0.example.com:443:127.0.0.1 https://echo0.example.com/sourcepath/something || {
     docker service logs caddy_test_caddy
     exit 1


### PR DESCRIPTION
This PR adds support for overriding the ingress network for a container via a `caddy_ingress_network` label. Relates to #157

~Pushing this up for any early feedback - the code compiles, but I still need to test & add docs and tests are ready.~
Should be ready to go.