### PR TITLE
Improve network matching and compatibility with host network

### DIFF
--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -26,6 +26,7 @@ const newLine = "\n"
 const containerIdLog = `INFO	Caddy ContainerID	{"ID": "container-id"}` + newLine
 const ingressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[network-id:true network-name:true]"}` + newLine
 const otherIngressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[other-network-id:true other-network-name:true]"}` + newLine
+const hostIngressNetworkMapLog = `INFO	IngressNetworksMap	{"ingres": "map[host:true host-id:true]"}` + newLine
 const swarmIsAvailableLog = `INFO	Swarm is available	{"new": true}` + newLine
 const swarmIsDisabledLog = `INFO	Swarm is available	{"new": false}` + newLine
 const commonLogs = containerIdLog + ingressNetworksMapLog + swarmIsAvailableLog

--- a/generator/services.go
+++ b/generator/services.go
@@ -76,13 +76,17 @@ func (g *CaddyfileGenerator) getServiceTasksIps(service *swarm.Service, logger *
 					} else if overrideNetwork {
 						include = networkAttachment.Network.Spec.Name == ingressNetworkFromLabel
 					} else {
-						include = g.ingressNetworks[networkAttachment.Network.ID]
+						include = g.ingressNetworks[networkAttachment.Network.ID] || g.ingressNetworks[networkAttachment.Network.Spec.Name]
 					}
 
 					if include {
-						for _, address := range networkAttachment.Addresses {
-							ipAddress, _, _ := net.ParseCIDR(address)
-							tasksIps = append(tasksIps, ipAddress.String())
+						if networkAttachment.Network.Spec.Name == "host" && len(networkAttachment.Addresses) == 0 {
+							tasksIps = append(tasksIps, "127.0.0.1")
+						} else {
+							for _, address := range networkAttachment.Addresses {
+								ipAddress, _, _ := net.ParseCIDR(address)
+								tasksIps = append(tasksIps, ipAddress.String())
+							}
 						}
 					}
 				}

--- a/tests/host-network/compose.yaml
+++ b/tests/host-network/compose.yaml
@@ -1,0 +1,41 @@
+version: '3.7'
+
+services:
+
+  caddy_server:
+    image: caddy-docker-proxy:local
+    networks:
+      - host
+    volumes:
+      - source: "${DOCKER_SOCKET_PATH}"
+        target: "${DOCKER_SOCKET_PATH}"
+        type: ${DOCKER_SOCKET_TYPE}
+
+  # Proxy to service
+  whoami0:
+    image: containous/whoami
+    command: ["-port", "8080"]
+    networks:
+      - host
+    deploy:
+      labels:
+        caddy: https://whoami0.example.com:4443
+        caddy.reverse_proxy: "{{upstreams 8080}}"
+        caddy.tls: "internal"
+
+  # Proxy to container
+  whoami1:
+    image: containous/whoami
+    command: ["-port", "8081"]
+    networks:
+      - host
+    labels:
+      caddy: https://whoami1.example.com:4443
+      caddy.reverse_proxy: "{{upstreams 8081}}"
+      caddy.tls: "internal"
+
+networks:
+  host:
+    name: 'host'
+    external: true
+

--- a/tests/host-network/run.sh
+++ b/tests/host-network/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+. ../functions.sh
+
+docker stack deploy -c compose.yaml --prune caddy_test
+
+retry curl --show-error -s -k -f --resolve whoami0.example.com:4443:127.0.0.1 https://whoami0.example.com:4443 &&
+    curl --show-error -s -k -f --resolve whoami1.example.com:4443:127.0.0.1 https://whoami1.example.com:4443 || {
+    docker service logs caddy_test_caddy_controller
+    docker service logs caddy_test_caddy_server
+    exit 1
+}


### PR DESCRIPTION
Issues fixed:
1. Network IDs in swarm tasks don't match the ID of the network, resulting in "Service is not in same network as caddy" and no upstreams. I changed it to match by network name as well.
2. HOST network as ingress network was resulting in no upstreams because there is no IP address information on host network attachments. I changed it to use 127.0.0.1 for those cases.

Test config is in: https://github.com/lucaslorentz/caddy-docker-proxy/blob/improve-network-matching/tests/host-network/compose.yaml . Note that no additional config was necessary and CDP properly recognized host network as ingress, and used 127.0.0.1 address to reach containers.

Fixes #558