### PR TITLE
Change scan-stopped-containers default value to false

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -61,7 +61,7 @@ func init() {
 			fs.Bool("process-caddyfile", true,
 				"Process Caddyfile before loading it, removing invalid servers")
 
-			fs.Bool("scan-stopped-containers", true,
+			fs.Bool("scan-stopped-containers", false,
 				"Scan stopped containers and use its labels for caddyfile generation")
 
 			fs.Duration("polling-interval", 30*time.Second,


### PR DESCRIPTION
Fixes https://github.com/lucaslorentz/caddy-docker-proxy/issues/556.

When we introduced "scan-stoped-containers" v2.8.7, it was intended to be false by default, but I accidentally enabled it by default.

Fixing this now. It is a breaking change for those who have been relying on it since 2.8.7, but a better behavior to have by default. More compatible with versions prior v2.8.7 as well.