### PR TITLE
Register docker_proxy caddy module

### DIFF
--- a/module.go
+++ b/module.go
@@ -1,0 +1,19 @@
+package caddydockerproxy
+
+import "github.com/caddyserver/caddy/v2"
+
+func init() {
+	caddy.RegisterModule(CaddyDockerProxy{})
+}
+
+// Caddy docker proxy module
+type CaddyDockerProxy struct {
+}
+
+// CaddyModule returns the Caddy module information.
+func (CaddyDockerProxy) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "docker_proxy",
+		New: func() caddy.Module { return new(CaddyDockerProxy) },
+	}
+}


### PR DESCRIPTION
Fixes #561.

```
# caddy list-modules --versions
...
docker_proxy v2.8.10

  Non-standard modules: 1
...
```