### PR TITLE
Update the whoami source 

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,9 +646,9 @@ $ docker stack rm caddy-docker-demo
 ```
 $ docker run --name caddy -d -p 443:443 -v /var/run/docker.sock:/var/run/docker.sock lucaslorentz/caddy-docker-proxy:ci-alpine
 
-$ docker run --name whoami0 -d -l caddy=whoami0.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal containous/whoami
+$ docker run --name whoami0 -d -l caddy=whoami0.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal traefik/whoami
 
-$ docker run --name whoami1 -d -l caddy=whoami1.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal containous/whoami
+$ docker run --name whoami1 -d -l caddy=whoami1.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal traefik/whoami
 
 $ curl -k --resolve whoami0.example.com:443:127.0.0.1 https://whoami0.example.com
 $ curl -k --resolve whoami1.example.com:443:127.0.0.1 https://whoami1.example.com

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ docker-compose up -d
 version: '3.7'
 services:
   whoami:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:

--- a/examples/distributed.yaml
+++ b/examples/distributed.yaml
@@ -35,7 +35,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -48,7 +48,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -59,7 +59,7 @@ services:
 
   # Proxy to container
   whoami2:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -69,7 +69,7 @@ services:
 
   # Proxy to container
   whoami3:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -79,7 +79,7 @@ services:
 
   # Proxy with matches and route
   echo_0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/examples/standalone.yaml
+++ b/examples/standalone.yaml
@@ -38,7 +38,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -49,7 +49,7 @@ services:
 
   # Proxy to service that you want to expose to the outside world
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -62,7 +62,7 @@ services:
 
   # Proxy to container
   whoami2:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -72,7 +72,7 @@ services:
 
   # Proxy to container
   whoami3:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -82,7 +82,7 @@ services:
 
   # Proxy with matches and route
   echo_0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/tests/caddyfile+config/compose.yaml
+++ b/tests/caddyfile+config/compose.yaml
@@ -28,7 +28,7 @@ services:
         caddy.email: "test@example.com"
 
   service:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/tests/containers/run.sh
+++ b/tests/containers/run.sh
@@ -8,9 +8,9 @@ trap "docker rm -f caddy whoami0 whoami1 whoami_stopped" EXIT
 
 {
     docker run --name caddy -d -p 4443:443 -e CADDY_DOCKER_SCAN_STOPPED_CONTAINERS=true -v /var/run/docker.sock:/var/run/docker.sock caddy-docker-proxy:local &&
-    docker run --name whoami0 -d -l caddy=whoami0.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal containous/whoami &&
-    docker run --name whoami1 -d -l caddy=whoami1.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal containous/whoami &&
-    docker create --name whoami_stopped -l caddy=whoami_stopped.example.com -l "caddy.respond=\"I'm a stopped container!\" 200" -l caddy.tls=internal containous/whoami &&
+    docker run --name whoami0 -d -l caddy=whoami0.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal traefik/whoami &&
+    docker run --name whoami1 -d -l caddy=whoami1.example.com -l "caddy.reverse_proxy={{upstreams 80}}" -l caddy.tls=internal traefik/whoami &&
+    docker create --name whoami_stopped -l caddy=whoami_stopped.example.com -l "caddy.respond=\"I'm a stopped container!\" 200" -l caddy.tls=internal traefik/whoami &&
 
     retry curl -k --resolve whoami0.example.com:4443:127.0.0.1 https://whoami0.example.com:4443 &&
     retry curl -k --resolve whoami1.example.com:4443:127.0.0.1 https://whoami1.example.com:4443 &&

--- a/tests/distributed/compose.yaml
+++ b/tests/distributed/compose.yaml
@@ -33,7 +33,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -44,7 +44,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -55,7 +55,7 @@ services:
 
   # Proxy to container
   whoami2:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -65,7 +65,7 @@ services:
 
   # Proxy to container
   whoami3:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -75,7 +75,7 @@ services:
 
   # Proxy with matches and route
   echo_0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/tests/ingress-networks/compose.yaml
+++ b/tests/ingress-networks/compose.yaml
@@ -35,7 +35,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - ingress_0
     deploy:
@@ -46,7 +46,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - ingress_1
     deploy:
@@ -57,7 +57,7 @@ services:
 
   # Proxy to service
   whoami2:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - internal
       - ingress_2

--- a/tests/process-caddyfile-off/compose_correct.yaml
+++ b/tests/process-caddyfile-off/compose_correct.yaml
@@ -18,7 +18,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -29,7 +29,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/tests/process-caddyfile-off/compose_wrong.yaml
+++ b/tests/process-caddyfile-off/compose_wrong.yaml
@@ -18,7 +18,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -29,7 +29,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/tests/process-caddyfile-on/compose_wrong.yaml
+++ b/tests/process-caddyfile-on/compose_wrong.yaml
@@ -18,7 +18,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -29,7 +29,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:

--- a/tests/standalone/compose.yaml
+++ b/tests/standalone/compose.yaml
@@ -16,7 +16,7 @@ services:
 
   # Proxy to service
   whoami0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -27,7 +27,7 @@ services:
 
   # Proxy to service
   whoami1:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:
@@ -38,7 +38,7 @@ services:
 
   # Proxy to container
   whoami2:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -48,7 +48,7 @@ services:
 
   # Proxy to container
   whoami3:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     labels:
@@ -58,7 +58,7 @@ services:
 
   # Proxy to container
   whoami4:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - internal
       - caddy
@@ -70,7 +70,7 @@ services:
 
   # Proxy with matches and route
   echo_0:
-    image: containous/whoami
+    image: traefik/whoami
     networks:
       - caddy
     deploy:


### PR DESCRIPTION
containous/whoami is deprecated and there is no arm image available. traefik/whoami should be used.
![grafik](https://github.com/lucaslorentz/caddy-docker-proxy/assets/1233864/4c50e544-ead6-4502-9280-054c1d7a5493)
