### PR TITLE
Fix broken block parsing when label prefix contains dots

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -38,7 +39,7 @@ type CaddyfileGenerator struct {
 
 // CreateGenerator creates a new generator
 func CreateGenerator(dockerClients []docker.Client, dockerUtils docker.Utils, options *config.Options) *CaddyfileGenerator {
-	var labelRegexString = fmt.Sprintf("^%s(_\\d+)?(\\.|$)", options.LabelPrefix)
+	var labelRegexString = fmt.Sprintf("^%s(_\\d+)?(\\.|$)", regexp.QuoteMeta(options.LabelPrefix))
 
 	return &CaddyfileGenerator{
 		options:          options,
@@ -284,6 +285,8 @@ func (g *CaddyfileGenerator) filterLabels(labels map[string]string) map[string]s
 	filteredLabels := map[string]string{}
 	for label, value := range labels {
 		if g.labelRegex.MatchString(label) {
+			// Canonicalize label prefix to "caddy", to prevent any meta characters in the prefix from causing problem in block parsing
+			label = strings.Replace(label, g.options.LabelPrefix, "caddy", 1)
 			filteredLabels[label] = value
 		}
 	}


### PR DESCRIPTION
When `CADDY_DOCKER_LABEL_PREFIX` contains dots, parsing of blocks will break.

e.g. With `CADDY_DOCKER_LABEL_PREFIX=mydomain.gitlab.caddy`, cdp will yield error:

```
[ERROR]  Removing invalid block: Caddyfile:2: unrecognized global option: gitlab\n{\n\tgitlab {\n\t\tcaddy http://redis.gitlab.mydomain {\n\t\t\treverse_proxy 127.0.0.1:5540\n\t\t}\n\t}\n}\n\n
```
Then wrongly parsed block is:
```
{
        gitlab {
                caddy http://redis.gitlab.mydomain {
                        reverse_proxy 127.0.0.1:5540
                }
        }
}
```

It is because `gitlab.caddy` in `mydomain.gitlab.caddy` also gets parsed as path.

Using dots in prefix conforms to what docker has adopted in their labels, e.g.:
```
            "com.docker.compose.project": "...",
            "com.docker.compose.project.config_files": "...",
            "com.docker.compose.project.working_dir": "...",
```

So using dot-separated string in `CADDY_DOCKER_LABEL_PREFIX` should be a good way to keep naming style consistent with other labels and should be supported.

This PR fixes it by canonicalizing the label prefix to `"caddy"`, so meta characters in user provided label prefix will not affect cdp's block parsing.