### PR TITLE
Shortcut for hostnames in local domain

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // working
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${fileDirname}",
+            //"logOutput": "dap",
+            //"showLog": true,
+            "stopOnEntry": true,
+            //"trace": "verbose",
+            "substitutePath": [{"from": "/home", "to": "/mnt/data1/home"}]
+        } ,
+       
+            {
+              "name": "Launch Caddy",
+              "type": "go",
+              "request": "launch",
+              "mode": "exec",
+              "program": "${workspaceFolder}/artifacts/binaries/linux/amd64/caddy", // the debug output of caddy
+              "args": ["docker-proxy", "--docker-sockets",  "\"unix:///var/run/docker.sock\"",
+                "--caddyfile-path", "~/dev/docker/scripts/mycaddy/Caddyfile",
+                ],
+                // --local-domain hkrose.ici --mode standalone --docker-sockets "unix:///var/run/docker.sock"
+              "cwd": "${workspaceFolder}"
+            }
+          
+    ]
+}

--- a/caddyfile/testdata/labels/local_domain.txt
+++ b/caddyfile/testdata/labels/local_domain.txt
@@ -1,6 +1,0 @@
-caddy               = {{ host app}}
-caddy.reverse_proxy = {{""}}
-----------
-app, app.localdomain {
-	reverse_proxy
-}

--- a/caddyfile/testdata/labels/local_domain.txt
+++ b/caddyfile/testdata/labels/local_domain.txt
@@ -1,0 +1,6 @@
+caddy               = {{ host app}}
+caddy.reverse_proxy = {{""}}
+----------
+app, app.localdomain {
+	reverse_proxy
+}

--- a/cmd.go
+++ b/cmd.go
@@ -258,6 +258,12 @@ func createOptions(flags caddycmd.Flags) *config.Options {
 		options.ScanStoppedContainers = scanStoppedContainersFlag
 	}
 
+	if localDomainEnv := os.Getenv("CADDY_DOCKER_LOCAL_DOMAIN"); localDomainEnv != "" {
+		options.LocalDomain = localDomainEnv
+	} else {
+		options.LocalDomain = localDomainFlag
+	}
+
 	if pollingIntervalEnv := os.Getenv("CADDY_DOCKER_POLLING_INTERVAL"); pollingIntervalEnv != "" {
 		if p, err := time.ParseDuration(pollingIntervalEnv); err != nil {
 			log.Error("Failed to parse CADDY_DOCKER_POLLING_INTERVAL", zap.String("CADDY_DOCKER_POLLING_INTERVAL", pollingIntervalEnv), zap.Error(err))

--- a/cmd.go
+++ b/cmd.go
@@ -153,6 +153,7 @@ func createOptions(flags caddycmd.Flags) *config.Options {
 	eventThrottleIntervalFlag := flags.Duration("event-throttle-interval")
 	modeFlag := flags.String("mode")
 	controllerSubnetFlag := flags.String("controller-network")
+	localDomainFlag := flags.String("local-domain")
 	dockerSocketsFlag := flags.String("docker-sockets")
 	dockerCertsPathFlag := flags.String("docker-certs-path")
 	dockerAPIsVersionFlag := flags.String("docker-apis-version")

--- a/config/options.go
+++ b/config/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	ProxyServiceTasks      bool
 	ProcessCaddyfile       bool
 	ScanStoppedContainers  bool
+	LocalDomain            string
 	PollingInterval        time.Duration
 	EventThrottleInterval  time.Duration
 	Mode                   Mode

--- a/generator/containers.go
+++ b/generator/containers.go
@@ -1,8 +1,6 @@
 package generator
 
 import (
-	"errors"
-
 	"github.com/docker/docker/api/types"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/caddyfile"
 	"go.uber.org/zap"
@@ -11,19 +9,9 @@ import (
 func (g *CaddyfileGenerator) getContainerCaddyfile(container *types.Container, logger *zap.Logger) (*caddyfile.Container, error) {
 	caddyLabels := g.filterLabels(container.Labels)
 
-	return labelsToCaddyfile(
-		caddyLabels,
-		container,
-		func() ([]string, error) {
-			return g.getContainerIPAddresses(container, logger, true)
-		},
-		func() (string, error) {
-			if g.options.LocalDomain == "" {
-				logger.Warn("local domain not defined in config")
-				return "", errors.New("Local domain not set")
-			}
-			return g.options.LocalDomain, nil
-		})
+	return labelsToCaddyfile(caddyLabels, container, g.getLocalDomain, func() ([]string, error) {
+		return g.getContainerIPAddresses(container, logger, true)
+	})
 }
 
 func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container, logger *zap.Logger, onlyIngressIps bool) ([]string, error) {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -288,4 +289,12 @@ func (g *CaddyfileGenerator) filterLabels(labels map[string]string) map[string]s
 		}
 	}
 	return filteredLabels
+}
+
+func (g *CaddyfileGenerator) getLocalDomain() (string, error) {
+	localDomain := g.options.LocalDomain
+	if localDomain == "" {
+		return "", errors.New("env variable LOCAL_DOMAIN is empty")
+	}
+	return localDomain, nil
 }

--- a/generator/labels_test.go
+++ b/generator/labels_test.go
@@ -48,6 +48,8 @@ func TestLabelsToCaddyfile(t *testing.T) {
 		// convert the labels to a Caddyfile
 		caddyfileBlock, err := labelsToCaddyfile(labels, nil, func() ([]string, error) {
 			return []string{"target"}, nil
+		}, func() (string, error) {
+			return "localdomain", nil
 		})
 
 		// if the result is nil then we expect an empty Caddyfile

--- a/generator/labels_test.go
+++ b/generator/labels_test.go
@@ -46,11 +46,13 @@ func TestLabelsToCaddyfile(t *testing.T) {
 		expectedCaddyfile = winNewlines.ReplaceAllString(expectedCaddyfile, "\n")
 
 		// convert the labels to a Caddyfile
-		caddyfileBlock, err := labelsToCaddyfile(labels, nil, func() ([]string, error) {
-			return []string{"target"}, nil
-		}, func() (string, error) {
-			return "localdomain", nil
-		})
+		caddyfileBlock, err := labelsToCaddyfile(labels, nil,
+			func() (string, error) {
+				return "localdomain", nil
+			},
+			func() ([]string, error) {
+				return []string{"target"}, nil
+			})
 
 		// if the result is nil then we expect an empty Caddyfile
 		// or an error message prefixed with "err: "

--- a/generator/services.go
+++ b/generator/services.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"context"
-	"errors"
 	"net"
 
 	"github.com/docker/docker/api/types"
@@ -16,19 +15,9 @@ import (
 func (g *CaddyfileGenerator) getServiceCaddyfile(service *swarm.Service, logger *zap.Logger) (*caddyfile.Container, error) {
 	caddyLabels := g.filterLabels(service.Spec.Labels)
 
-	return labelsToCaddyfile(
-		caddyLabels,
-		service,
-		func() ([]string, error) {
-			return g.getServiceProxyTargets(service, logger, true)
-		},
-		func() (string, error) {
-			if g.options.LocalDomain == "" {
-				logger.Warn("local domain not defined in config")
-				return "", errors.New("Local domain not set")
-			}
-			return g.options.LocalDomain, nil
-		})
+	return labelsToCaddyfile(caddyLabels, service, g.getLocalDomain, func() ([]string, error) {
+		return g.getServiceProxyTargets(service, logger, true)
+	})
 }
 
 func (g *CaddyfileGenerator) getServiceProxyTargets(service *swarm.Service, logger *zap.Logger, onlyIngressIps bool) ([]string, error) {

--- a/generator/testdata/labels/local_domain.txt
+++ b/generator/testdata/labels/local_domain.txt
@@ -1,0 +1,6 @@
+caddy               = {{domain "app"}}
+caddy.reverse_proxy = {{upstreams}}
+----------
+app app.localdomain {
+	reverse_proxy target
+}

--- a/generator/testdata/labels/local_domain.txt
+++ b/generator/testdata/labels/local_domain.txt
@@ -1,4 +1,4 @@
-caddy               = {{domain "app"}}
+caddy               = {{addDomain "app"}}
 caddy.reverse_proxy = {{upstreams}}
 ----------
 app app.localdomain {

--- a/loader.go
+++ b/loader.go
@@ -154,6 +154,7 @@ func (dockerLoader *DockerLoader) Start() error {
 		zap.Bool("ProxyServiceTasks", dockerLoader.options.ProxyServiceTasks),
 		zap.Bool("ProcessCaddyfile", dockerLoader.options.ProcessCaddyfile),
 		zap.Bool("ScanStoppedContainers", dockerLoader.options.ScanStoppedContainers),
+		zap.String("LocalDomain", dockerLoader.options.LocalDomain),
 		zap.String("IngressNetworks", fmt.Sprintf("%v", dockerLoader.options.IngressNetworks)),
 		zap.Strings("DockerSockets", dockerLoader.options.DockerSockets),
 		zap.Strings("DockerCertsPath", dockerLoader.options.DockerCertsPath),


### PR DESCRIPTION
Allow to label a container with

`--label caddy="@(myservice)"`

which will translate to reverse proxy to "_myservice_" and "_myservice_.<localdomain>" where local domain is provided as config parameter.

This is a very naive implementation as this is my first try of GO so do not hesitate to comment on the implementation and I'll try to improve.

I made an attempt to rather use GO template but this creates too much burden. 

Tentative implementation for #652
