### PR TITLE
update docker api and remove deprecated types

### DIFF
--- a/docker/client.go
+++ b/docker/client.go
@@ -4,17 +4,19 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
 )
 
 // Client is an interface with needed functionalities from docker client
 type Client interface {
-	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+	ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error)
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
-	Info(ctx context.Context) (types.Info, error)
+	Info(ctx context.Context) (system.Info, error)
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
 	NetworkInspect(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
@@ -34,7 +36,7 @@ type clientWrapper struct {
 	client *client.Client
 }
 
-func (wrapper *clientWrapper) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+func (wrapper *clientWrapper) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
 	return wrapper.client.ContainerList(ctx, options)
 }
 
@@ -50,7 +52,7 @@ func (wrapper *clientWrapper) ConfigList(ctx context.Context, options types.Conf
 	return wrapper.client.ConfigList(ctx, options)
 }
 
-func (wrapper *clientWrapper) Info(ctx context.Context) (types.Info, error) {
+func (wrapper *clientWrapper) Info(ctx context.Context) (system.Info, error) {
 	return wrapper.client.Info(ctx)
 }
 

--- a/docker/client_mock.go
+++ b/docker/client_mock.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 )
 
 // ClientMock allows easily mocking of docker client data
@@ -15,7 +17,7 @@ type ClientMock struct {
 	ConfigsData          []swarm.Config
 	TasksData            []swarm.Task
 	NetworksData         []types.NetworkResource
-	InfoData             types.Info
+	InfoData             system.Info
 	ContainerInspectData map[string]types.ContainerJSON
 	NetworkInspectData   map[string]types.NetworkResource
 	EventsChannel        chan events.Message
@@ -23,7 +25,7 @@ type ClientMock struct {
 }
 
 // ContainerList list all containers
-func (mock *ClientMock) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+func (mock *ClientMock) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
 	return mock.ContainersData, nil
 }
 
@@ -58,7 +60,7 @@ func (mock *ClientMock) NetworkList(ctx context.Context, options types.NetworkLi
 }
 
 // Info retrieves information about docker host
-func (mock *ClientMock) Info(ctx context.Context) (types.Info, error) {
+func (mock *ClientMock) Info(ctx context.Context) (system.Info, error) {
 	return mock.InfoData, nil
 }
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/caddyfile"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
@@ -117,7 +118,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 		}
 
 		// Add containers
-		containers, err := dockerClient.ContainerList(context.Background(), types.ContainerListOptions{All: g.options.ScanStoppedContainers})
+		containers, err := dockerClient.ContainerList(context.Background(), container.ListOptions{All: g.options.ScanStoppedContainers})
 		if err == nil {
 			for _, container := range containers {
 				if _, isControlledServer := container.Labels[g.options.ControlledServersLabel]; isControlledServer {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/docker"
 	"github.com/stretchr/testify/assert"
@@ -165,7 +166,7 @@ func createBasicDockerClientMock() *docker.ClientMock {
 		ConfigsData:    []swarm.Config{},
 		TasksData:      []swarm.Task{},
 		NetworksData:   []types.NetworkResource{},
-		InfoData: types.Info{
+		InfoData: system.Info{
 			Swarm: swarm.Info{
 				LocalNodeState: swarm.LocalNodeStateActive,
 			},

--- a/generator/services_test.go
+++ b/generator/services_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
 )
 
@@ -161,7 +162,7 @@ func TestServices_SwarmDisabled(t *testing.T) {
 			},
 		},
 	}
-	dockerClient.InfoData = types.Info{
+	dockerClient.InfoData = system.Info{
 		Swarm: swarm.Info{
 			LocalNodeState: swarm.LocalNodeStateInactive,
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.8
 
 require (
 	github.com/caddyserver/caddy/v2 v2.8.4
-	github.com/docker/docker v25.0.6+incompatible
+	github.com/docker/docker v27.5.1+incompatible
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
@@ -87,6 +87,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55k
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/docker v25.0.6+incompatible h1:5cPwbwriIcsua2REJe8HqQV+6WlWc1byg2QSXzBxBGg=
-github.com/docker/docker v25.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.5.1+incompatible h1:4PYU5dnBYqRQi0294d1FBECqT9ECWeQAIfE8q4YnPY8=
+github.com/docker/docker v27.5.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -332,6 +332,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=


### PR DESCRIPTION
I try to build this with caddy-crowdsec-bouncer and #694 happened. I investigate the cause and found that this module has an outdated docker api version. Looking at #658 which is not solving the issue, I try to fix it and create this PR.

My custom caddy built successfully hence this PR.