### PR TITLE
Add UDP port mapping for HTTP/3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ services:
     image: lucaslorentz/caddy-docker-proxy:ci-alpine
     ports:
       - 80:80
-      - 443:443
+      - 443:443/tcp
+      - 443:443/udp
     environment:
       - CADDY_INGRESS_NETWORKS=caddy
     networks:

--- a/examples/distributed.yaml
+++ b/examples/distributed.yaml
@@ -6,7 +6,8 @@ services:
     image: lucaslorentz/caddy-docker-proxy:ci-alpine
     ports:
       - 80:80
-      - 443:443
+      - 443:443/tcp
+      - 443:443/udp
     networks:
       - caddy_controller
       - caddy

--- a/examples/standalone.yaml
+++ b/examples/standalone.yaml
@@ -14,7 +14,8 @@ services:
     image: lucaslorentz/caddy-docker-proxy:ci-alpine
     ports:
       - 80:80
-      - 443:443
+      - 443:443/tcp
+      - 443:443/udp
     networks:
       - caddy
     volumes:


### PR DESCRIPTION
Enable HTTP/3 by exposing port 443 for both TCP and UDP protocols to all Docker Compose examples.