### PR TITLE
Update Caddyfile on network event

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -54,13 +54,11 @@ func CreateGenerator(dockerClients []docker.Client, dockerUtils docker.Utils, op
 func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []string) {
 	var caddyfileBuffer bytes.Buffer
 
-	if g.ingressNetworks == nil {
-		ingressNetworks, err := g.getIngressNetworks(logger)
-		if err == nil {
-			g.ingressNetworks = ingressNetworks
-		} else {
-			logger.Error("Failed to get ingress networks", zap.Error(err))
-		}
+	ingressNetworks, err := g.getIngressNetworks(logger)
+	if err == nil {
+		g.ingressNetworks = ingressNetworks
+	} else {
+		logger.Error("Failed to get ingress networks", zap.Error(err))
 	}
 
 	if time.Since(g.swarmIsAvailableTime) > swarmAvailabilityCacheInterval {

--- a/loader.go
+++ b/loader.go
@@ -189,6 +189,7 @@ func (dockerLoader *DockerLoader) listenEvents() {
 	args.Add("type", "service")
 	args.Add("type", "container")
 	args.Add("type", "config")
+	args.Add("type", "network")
 
 	for i, dockerClient := range dockerLoader.dockerClients {
 		context, cancel := context.WithCancel(context.Background())
@@ -217,7 +218,9 @@ func (dockerLoader *DockerLoader) listenEvents() {
 					(event.Type == "service" && event.Action == "update") ||
 					(event.Type == "service" && event.Action == "remove") ||
 					(event.Type == "config" && event.Action == "create") ||
-					(event.Type == "config" && event.Action == "remove")
+					(event.Type == "config" && event.Action == "remove") ||
+					(event.Type == "network" && event.Action == "connect") ||
+					(event.Type == "network" && event.Action == "disconnect")
 
 				if update {
 					dockerLoader.skipEvents[i] = true


### PR DESCRIPTION
I'm using https://git.sr.ht/~tomleb/docker-network-autoconnect to help manage networks between my applications (eg: bookstack, audiobookshelf, etc) and caddy. This means that the networks connected caddy are dynamically added/removed.

I found two problems with CDP, I fixed it with the commits here and that works for my use case.

1. CDP doesn't regenerates the Caddyfile when networks are connected/disconnected to caddy
2. The list of networks connected to caddy is computed once and reused.

This PR fixed both, by:
1. Reacting to docker network events. (This could be more specific eg: by filtering further the event to only caddy, but heh)
2. We're re-computing the list of networks every generation step

Not sure if this is needed or if this use case makes sense in general (probably though?), still I'm putting this PR up if anybody else needs this.