### PR TITLE
Fix admin off regression from PR #775

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -355,8 +355,9 @@ func addAdminListen(configJSON []byte, listen string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Respect explicit admin settings from Caddyfile/JSON config.
-	if config.Admin != nil {
+	// Respect explicit admin settings from Caddyfile/JSON config,
+	// but override "admin off" since the plugin requires the admin API.
+	if config.Admin != nil && !config.Admin.Disabled {
 		return configJSON, nil
 	}
 	config.Admin = &caddy.AdminConfig{

--- a/loader_test.go
+++ b/loader_test.go
@@ -42,6 +42,25 @@ func TestAddAdminListenKeepsExistingAdminListen(t *testing.T) {
 	assert.Equal(t, "tcp/0.0.0.0:2019", result.Admin.Listen)
 }
 
+func TestAddAdminListenOverridesAdminOff(t *testing.T) {
+	input, err := json.Marshal(&caddy.Config{
+		Admin: &caddy.AdminConfig{
+			Disabled: true,
+		},
+	})
+	require.NoError(t, err)
+
+	output, err := addAdminListen(input, "tcp/localhost:2019")
+	require.NoError(t, err)
+
+	result := &caddy.Config{}
+	err = json.Unmarshal(output, result)
+	require.NoError(t, err)
+	require.NotNil(t, result.Admin)
+	assert.False(t, result.Admin.Disabled)
+	assert.Equal(t, "tcp/localhost:2019", result.Admin.Listen)
+}
+
 func TestGetServerAdminListen(t *testing.T) {
 	assert.Equal(t, "tcp/10.0.0.2:2019", getServerAdminListen(&config.Options{}, "10.0.0.2"))
 	assert.Equal(t, "tcp/0.0.0.0:2019", getServerAdminListen(&config.Options{AdminListen: "tcp/0.0.0.0:2019"}, "10.0.0.2"))


### PR DESCRIPTION
## Summary
- PR #775 changed `addAdminListen()` to preserve user-defined `admin` config, but this also preserved `admin off` from Caddyfile, which disables the admin API that the plugin requires to push config updates
- Now only preserves user admin config when it's not disabling admin entirely (`!config.Admin.Disabled`)
- Adds test for the `admin off` case

Fixes #780

## Test plan
- [x] Existing tests pass (`TestAddAdminListenKeepsExistingAdminListen` — custom admin listen still preserved)
- [x] New test passes (`TestAddAdminListenOverridesAdminOff` — `admin off` is overridden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)