### PR TITLE
Fix test expectations after IngressNetworksMap log level change

### DIFF
--- a/generator/containers_test.go
+++ b/generator/containers_test.go
@@ -131,7 +131,7 @@ func TestContainers_ManualIngressNetworks(t *testing.T) {
 		"	reverse_proxy 10.0.0.1\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
+	const expectedLogs = swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -177,7 +177,7 @@ func TestContainers_OverrideIngressNetworks(t *testing.T) {
 		"	reverse_proxy 10.0.0.2\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
+	const expectedLogs = swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -25,11 +25,9 @@ var caddyNetworkName = "network-name"
 
 const newLine = "\n"
 const containerIdLog = `INFO	Caddy ContainerID	{"ID": "container-id"}` + newLine
-const ingressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[network-id:true network-name:true]"}` + newLine
-const otherIngressNetworksMapLog = `INFO	IngressNetworksMap	{"ingres": "map[other-network-id:true other-network-name:true]"}` + newLine
 const swarmIsAvailableLog = `INFO	Swarm is available	{"new": true}` + newLine
 const swarmIsDisabledLog = `INFO	Swarm is available	{"new": false}` + newLine
-const commonLogs = containerIdLog + ingressNetworksMapLog + swarmIsAvailableLog
+const commonLogs = containerIdLog + swarmIsAvailableLog
 
 func init() {
 	log.SetOutput(io.Discard)

--- a/generator/services_test.go
+++ b/generator/services_test.go
@@ -132,7 +132,7 @@ func TestServices_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy service\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
+	const expectedLogs = swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.IngressNetworks = []string{"other-network-name"}
@@ -170,7 +170,7 @@ func TestServices_SwarmDisabled(t *testing.T) {
 
 	const expectedCaddyfile = "# Empty caddyfile"
 
-	const expectedLogs = containerIdLog + ingressNetworksMapLog + swarmIsDisabledLog
+	const expectedLogs = containerIdLog + swarmIsDisabledLog
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
@@ -375,7 +375,7 @@ func TestServiceTasks_ManualIngressNetwork(t *testing.T) {
 		"	reverse_proxy 10.0.0.1:5000\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
+	const expectedLogs = swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
@@ -453,7 +453,7 @@ func TestServiceTasks_OverrideIngressNetwork(t *testing.T) {
 		"	reverse_proxy 10.0.0.2:5000\n" +
 		"}\n"
 
-	const expectedLogs = otherIngressNetworksMapLog + swarmIsAvailableLog
+	const expectedLogs = swarmIsAvailableLog
 
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true


### PR DESCRIPTION
## Summary
- PR #777 moved `IngressNetworksMap` log from INFO to DEBUG, but didn't update test expectations
- Tests assert on INFO-level log output, so the now-DEBUG line no longer appears
- Removes the `ingressNetworksMapLog` and `otherIngressNetworksMapLog` constants and updates all affected tests

## Test plan
- [x] All tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)