### PR TITLE
Make docker sockets optional with retry/reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,8 @@ Run `caddy help docker-proxy` to see the raw flag output.
 | `--docker-sockets` | `CADDY_DOCKER_SOCKETS` | Comma-separated Docker sockets.<br>**Default:** `DOCKER_HOST` or the default socket |
 | `--docker-certs-path` | `CADDY_DOCKER_CERTS_PATH` | Comma-separated cert paths (one per socket; leave entry empty for sockets without certs) |
 | `--docker-apis-version` | `CADDY_DOCKER_APIS_VERSION` | Comma-separated API versions (one per socket) |
+| `--docker-retry-min` | `CADDY_DOCKER_RETRY_MIN` | Minimum retry interval for Docker socket reconnection (see [Optional Docker Sockets](#optional-docker-sockets)).<br>**Default:** `1s` |
+| `--docker-retry-max` | `CADDY_DOCKER_RETRY_MAX` | Maximum retry interval for Docker socket reconnection (see [Optional Docker Sockets](#optional-docker-sockets)).<br>**Default:** `30s` |
 | `--controller-network` | `CADDY_CONTROLLER_NETWORK` | Network allowed to configure the Caddy server, in CIDR (e.g. `10.200.200.0/24`) |
 | `--ingress-networks` | `CADDY_INGRESS_NETWORKS` | Comma-separated ingress networks connecting Caddy to containers.<br>**Default:** networks attached to the controller container |
 | `--caddyfile-path` | `CADDY_DOCKER_CADDYFILE_PATH` | Path to a base Caddyfile that will be extended with Docker sites |
@@ -514,6 +516,16 @@ Run `caddy help docker-proxy` to see the raw flag output.
 | _(env only)_ | `CADDY_DOCKER_NO_SCOPE` | Disable Docker event scope filter (useful for Podman).<br>**Default:** `false` |
 
 Check the **examples** folder to see how to set them in a Docker Compose file.
+
+## Optional Docker Sockets
+
+When multiple docker sockets are specified via `--docker-sockets` (or `CADDY_DOCKER_SOCKETS`), each socket is treated as optional. If a socket is unavailable at startup, caddy-docker-proxy logs a warning and retries with exponential backoff. When the socket becomes available, its containers and services are immediately incorporated into the Caddyfile.
+
+If a previously connected socket goes down, its routes are removed from the Caddyfile on the next regeneration cycle.
+
+Retry timing is controlled by `--docker-retry-min` (default `1s`) and `--docker-retry-max` (default `30s`). The retry interval starts at the minimum and doubles after each failed attempt until it reaches the maximum.
+
+The default behavior (no `--docker-sockets` flag) is unchanged — a single docker socket is required and a connection failure at startup is a fatal error.
 
 ## Viewing the generated Caddyfile
 

--- a/cmd.go
+++ b/cmd.go
@@ -70,6 +70,12 @@ func init() {
 			fs.Duration("event-throttle-interval", 100*time.Millisecond,
 				"Interval to throttle caddyfile updates triggered by docker events")
 
+			fs.Duration("docker-retry-min", 1*time.Second,
+				"Minimum retry interval for docker socket reconnection")
+
+			fs.Duration("docker-retry-max", 30*time.Second,
+				"Maximum retry interval for docker socket reconnection")
+
 			return fs
 		}(),
 	})
@@ -172,6 +178,8 @@ func createOptions(flags caddycmd.Flags) *config.Options {
 	dockerCertsPathFlag := flags.String("docker-certs-path")
 	dockerAPIsVersionFlag := flags.String("docker-apis-version")
 	ingressNetworksFlag := flags.String("ingress-networks")
+	dockerRetryMinFlag := flags.Duration("docker-retry-min")
+	dockerRetryMaxFlag := flags.Duration("docker-retry-max")
 
 	options := &config.Options{}
 
@@ -295,6 +303,28 @@ func createOptions(flags caddycmd.Flags) *config.Options {
 		}
 	} else {
 		options.EventThrottleInterval = eventThrottleIntervalFlag
+	}
+
+	if dockerRetryMinEnv := os.Getenv("CADDY_DOCKER_RETRY_MIN"); dockerRetryMinEnv != "" {
+		if p, err := time.ParseDuration(dockerRetryMinEnv); err != nil {
+			log.Error("Failed to parse CADDY_DOCKER_RETRY_MIN", zap.String("CADDY_DOCKER_RETRY_MIN", dockerRetryMinEnv), zap.Error(err))
+			options.DockerRetryMin = dockerRetryMinFlag
+		} else {
+			options.DockerRetryMin = p
+		}
+	} else {
+		options.DockerRetryMin = dockerRetryMinFlag
+	}
+
+	if dockerRetryMaxEnv := os.Getenv("CADDY_DOCKER_RETRY_MAX"); dockerRetryMaxEnv != "" {
+		if p, err := time.ParseDuration(dockerRetryMaxEnv); err != nil {
+			log.Error("Failed to parse CADDY_DOCKER_RETRY_MAX", zap.String("CADDY_DOCKER_RETRY_MAX", dockerRetryMaxEnv), zap.Error(err))
+			options.DockerRetryMax = dockerRetryMaxFlag
+		} else {
+			options.DockerRetryMax = p
+		}
+	} else {
+		options.DockerRetryMax = dockerRetryMaxFlag
 	}
 
 	return options

--- a/config/options.go
+++ b/config/options.go
@@ -13,6 +13,8 @@ type Options struct {
 	DockerSockets          []string
 	DockerCertsPath        []string
 	DockerAPIsVersion      []string
+	DockerRetryMin         time.Duration
+	DockerRetryMax         time.Duration
 	LabelPrefix            string
 	ControlledServersLabel string
 	ProxyServiceTasks      bool

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/caddyfile"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/docker"
@@ -271,6 +272,10 @@ func (g *CaddyfileGenerator) getIngressNetworks(dockerClients []docker.Client, l
 			logger.Debug("Caddy ContainerID", zap.String("ID", containerID))
 			container, err := dockerClient.ContainerInspect(context.Background(), containerID)
 			if err != nil {
+				if errdefs.IsNotFound(err) {
+					// caddy container lives on one socket; others won't have it
+					continue
+				}
 				return nil, err
 			}
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -28,11 +28,15 @@ const IngressNetworkLabel = "caddy_ingress_network"
 
 const swarmAvailabilityCacheInterval = 1 * time.Minute
 
+// ClientProvider returns the current set of connected docker clients
+type ClientProvider func() []docker.Client
+
 // CaddyfileGenerator generates caddyfile from docker configuration
 type CaddyfileGenerator struct {
 	options              *config.Options
 	labelRegex           *regexp.Regexp
-	dockerClients        []docker.Client
+	clientProvider       ClientProvider
+	dockerClients        []docker.Client // set per-call in GenerateCaddyfile for downstream methods
 	dockerUtils          docker.Utils
 	ingressNetworks      map[string]bool
 	swarmIsAvailable     []bool
@@ -40,31 +44,39 @@ type CaddyfileGenerator struct {
 }
 
 // CreateGenerator creates a new generator
-func CreateGenerator(dockerClients []docker.Client, dockerUtils docker.Utils, options *config.Options) *CaddyfileGenerator {
+func CreateGenerator(clientProvider ClientProvider, dockerUtils docker.Utils, options *config.Options) *CaddyfileGenerator {
 	var labelRegexString = fmt.Sprintf("^%s(_\\d+)?(\\.|$)", regexp.QuoteMeta(options.LabelPrefix))
 
 	return &CaddyfileGenerator{
-		options:          options,
-		labelRegex:       regexp.MustCompile(labelRegexString),
-		dockerClients:    dockerClients,
-		swarmIsAvailable: make([]bool, len(dockerClients)),
-		dockerUtils:      dockerUtils,
+		options:        options,
+		labelRegex:     regexp.MustCompile(labelRegexString),
+		clientProvider: clientProvider,
+		dockerUtils:    dockerUtils,
 	}
 }
 
 // GenerateCaddyfile generates a caddy file config from docker metadata
 func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []string) {
+	dockerClients := g.clientProvider()
+	g.dockerClients = dockerClients
+
+	// Rebuild swarm availability tracking when the client count changes
+	clientCountChanged := len(g.swarmIsAvailable) != len(dockerClients)
+	if clientCountChanged {
+		g.swarmIsAvailable = make([]bool, len(dockerClients))
+	}
+
 	var caddyfileBuffer bytes.Buffer
 
-	ingressNetworks, err := g.getIngressNetworks(logger)
+	ingressNetworks, err := g.getIngressNetworks(dockerClients, logger)
 	if err == nil {
 		g.ingressNetworks = ingressNetworks
 	} else {
 		logger.Error("Failed to get ingress networks", zap.Error(err))
 	}
 
-	if time.Since(g.swarmIsAvailableTime) > swarmAvailabilityCacheInterval {
-		g.checkSwarmAvailability(logger, time.Time.IsZero(g.swarmIsAvailableTime))
+	if clientCountChanged || time.Since(g.swarmIsAvailableTime) > swarmAvailabilityCacheInterval {
+		g.checkSwarmAvailability(dockerClients, logger, time.Time.IsZero(g.swarmIsAvailableTime))
 		g.swarmIsAvailableTime = time.Now()
 	}
 
@@ -88,7 +100,7 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 		logger.Debug("Skipping default Caddyfile because no path is set")
 	}
 
-	for i, dockerClient := range g.dockerClients {
+	for i, dockerClient := range dockerClients {
 
 		// Add Caddyfile from swarm configs
 		if g.swarmIsAvailable[i] {
@@ -214,9 +226,9 @@ func (g *CaddyfileGenerator) GenerateCaddyfile(logger *zap.Logger) ([]byte, []st
 	return caddyfileContent, controlledServers
 }
 
-func (g *CaddyfileGenerator) checkSwarmAvailability(logger *zap.Logger, isFirstCheck bool) {
+func (g *CaddyfileGenerator) checkSwarmAvailability(dockerClients []docker.Client, logger *zap.Logger, isFirstCheck bool) {
 
-	for i, dockerClient := range g.dockerClients {
+	for i, dockerClient := range dockerClients {
 		info, err := dockerClient.Info(context.Background())
 		if err == nil {
 			newSwarmIsAvailable := info.Swarm.LocalNodeState == swarm.LocalNodeStateActive
@@ -231,10 +243,10 @@ func (g *CaddyfileGenerator) checkSwarmAvailability(logger *zap.Logger, isFirstC
 	}
 }
 
-func (g *CaddyfileGenerator) getIngressNetworks(logger *zap.Logger) (map[string]bool, error) {
+func (g *CaddyfileGenerator) getIngressNetworks(dockerClients []docker.Client, logger *zap.Logger) (map[string]bool, error) {
 	ingressNetworks := map[string]bool{}
 
-	for _, dockerClient := range g.dockerClients {
+	for _, dockerClient := range dockerClients {
 		if len(g.options.IngressNetworks) > 0 {
 			networks, err := dockerClient.NetworkList(context.Background(), network.ListOptions{})
 			if err != nil {

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -141,7 +141,11 @@ func testGeneration(
 		customizeOptions(options)
 	}
 
-	generator := CreateGenerator([]docker.Client{dockerClient}, dockerUtils, options)
+	clientProvider := func() []docker.Client {
+		return []docker.Client{dockerClient}
+	}
+
+	generator := CreateGenerator(clientProvider, dockerUtils, options)
 
 	var logsBuffer bytes.Buffer
 	encoderConfig := zap.NewDevelopmentEncoderConfig()

--- a/loader.go
+++ b/loader.go
@@ -15,8 +15,6 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
-	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/joho/godotenv"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
@@ -33,10 +31,10 @@ var CaddyfileAutosavePath = filepath.Join(caddy.AppConfigDir(), "Caddyfile.autos
 type DockerLoader struct {
 	options         *config.Options
 	initialized     bool
-	dockerClients   []docker.Client
+	mu              sync.RWMutex
+	socketManagers  []*socketManager
 	generator       *generator.CaddyfileGenerator
 	timer           *time.Timer
-	skipEvents      []bool
 	lastCaddyfile   []byte
 	lastJSONConfig  []byte
 	lastVersion     int64
@@ -51,6 +49,37 @@ func CreateDockerLoader(options *config.Options) *DockerLoader {
 		serversVersions: utils.NewStringInt64CMap(),
 		serversUpdating: utils.NewStringBoolCMap(),
 	}
+}
+
+// getConnectedClients returns a snapshot of all currently connected docker clients.
+func (dockerLoader *DockerLoader) getConnectedClients() []docker.Client {
+	dockerLoader.mu.RLock()
+	defer dockerLoader.mu.RUnlock()
+
+	clients := []docker.Client{}
+	for _, sm := range dockerLoader.socketManagers {
+		if sm.client != nil {
+			clients = append(clients, sm.client)
+		}
+	}
+	return clients
+}
+
+// setClient sets or clears a socket manager's client under write lock.
+func (dockerLoader *DockerLoader) setClient(sm *socketManager, c docker.Client) {
+	dockerLoader.mu.Lock()
+	defer dockerLoader.mu.Unlock()
+	sm.client = c
+}
+
+// triggerUpdate triggers an immediate Caddyfile regeneration.
+func (dockerLoader *DockerLoader) triggerUpdate() {
+	dockerLoader.timer.Reset(0)
+}
+
+// triggerThrottledUpdate triggers a throttled Caddyfile regeneration.
+func (dockerLoader *DockerLoader) triggerThrottledUpdate() {
+	dockerLoader.timer.Reset(dockerLoader.options.EventThrottleInterval)
 }
 
 func logger() *zap.Logger {
@@ -75,49 +104,32 @@ func (dockerLoader *DockerLoader) Start() error {
 		log.Info("environment file loaded", zap.String("envFile", dockerLoader.options.EnvFile))
 	}
 
-	dockerClients := []docker.Client{}
-	for i, dockerSocket := range dockerLoader.options.DockerSockets {
-		// cf https://github.com/docker/go-docker/blob/master/client.go
-		// setenv to use NewEnvClient
-		// or manually
+	if len(dockerLoader.options.DockerSockets) > 0 {
+		// Multi-socket mode: each socket is optional with retry
+		for i, dockerSocket := range dockerLoader.options.DockerSockets {
+			certsPath := ""
+			if len(dockerLoader.options.DockerCertsPath) >= i+1 {
+				certsPath = dockerLoader.options.DockerCertsPath[i]
+			}
 
-		os.Setenv("DOCKER_HOST", dockerSocket)
+			apiVersion := ""
+			if len(dockerLoader.options.DockerAPIsVersion) >= i+1 {
+				apiVersion = dockerLoader.options.DockerAPIsVersion[i]
+			}
 
-		if len(dockerLoader.options.DockerCertsPath) >= i+1 && dockerLoader.options.DockerCertsPath[i] != "" {
-			os.Setenv("DOCKER_CERT_PATH", dockerLoader.options.DockerCertsPath[i])
-		} else {
-			os.Unsetenv("DOCKER_CERT_PATH")
+			sm := newSocketManager(
+				dockerSocket,
+				certsPath,
+				apiVersion,
+				dockerLoader.options.DockerRetryMin,
+				dockerLoader.options.DockerRetryMax,
+				dockerLoader,
+			)
+			dockerLoader.socketManagers = append(dockerLoader.socketManagers, sm)
 		}
-
-		if len(dockerLoader.options.DockerAPIsVersion) >= i+1 && dockerLoader.options.DockerAPIsVersion[i] != "" {
-			os.Setenv("DOCKER_API_VERSION", dockerLoader.options.DockerAPIsVersion[i])
-		} else {
-			os.Unsetenv("DOCKER_API_VERSION")
-		}
-
+	} else {
+		// Default single-socket mode: strict, fail on error (backwards compat)
 		dockerClient, err := client.NewEnvClient()
-		if err != nil {
-			log.Error("Docker connection failed to docker specify socket", zap.Error(err), zap.String("DockerSocket", dockerSocket))
-			return err
-		}
-
-		dockerPing, err := dockerClient.Ping(context.Background())
-		if err != nil {
-			log.Error("Docker ping failed on specify socket", zap.Error(err), zap.String("DockerSocket", dockerSocket))
-			return err
-		}
-
-		dockerClient.NegotiateAPIVersionPing(dockerPing)
-
-		wrappedClient := docker.WrapClient(dockerClient)
-
-		dockerClients = append(dockerClients, wrappedClient)
-	}
-
-	// by default it will used the env docker
-	if len(dockerClients) == 0 {
-		dockerClient, err := client.NewEnvClient()
-		dockerLoader.options.DockerSockets = append(dockerLoader.options.DockerSockets, os.Getenv("DOCKER_HOST"))
 		if err != nil {
 			log.Error("Docker connection failed", zap.Error(err))
 			return err
@@ -130,17 +142,22 @@ func (dockerLoader *DockerLoader) Start() error {
 		}
 
 		dockerClient.NegotiateAPIVersionPing(dockerPing)
-
 		wrappedClient := docker.WrapClient(dockerClient)
 
-		dockerClients = append(dockerClients, wrappedClient)
+		// Create a socket manager that is already connected (no retry loop)
+		sm := &socketManager{
+			socket:   os.Getenv("DOCKER_HOST"),
+			retryMin: dockerLoader.options.DockerRetryMin,
+			retryMax: dockerLoader.options.DockerRetryMax,
+			client:   wrappedClient,
+			loader:   dockerLoader,
+		}
+		dockerLoader.socketManagers = append(dockerLoader.socketManagers, sm)
+		dockerLoader.options.DockerSockets = append(dockerLoader.options.DockerSockets, sm.socket)
 	}
 
-	dockerLoader.dockerClients = dockerClients
-	dockerLoader.skipEvents = make([]bool, len(dockerLoader.dockerClients))
-
 	dockerLoader.generator = generator.CreateGenerator(
-		dockerClients,
+		dockerLoader.getConnectedClients,
 		docker.CreateUtils(),
 		dockerLoader.options,
 	)
@@ -158,6 +175,8 @@ func (dockerLoader *DockerLoader) Start() error {
 		zap.Strings("DockerSockets", dockerLoader.options.DockerSockets),
 		zap.Strings("DockerCertsPath", dockerLoader.options.DockerCertsPath),
 		zap.Strings("DockerAPIsVersion", dockerLoader.options.DockerAPIsVersion),
+		zap.Duration("DockerRetryMin", dockerLoader.options.DockerRetryMin),
+		zap.Duration("DockerRetryMax", dockerLoader.options.DockerRetryMax),
 		zap.String("CaddyfileAutosavePath", CaddyfileAutosavePath),
 	)
 
@@ -168,80 +187,24 @@ func (dockerLoader *DockerLoader) Start() error {
 	})
 	close(ready)
 
-	go dockerLoader.monitorEvents()
+	// Start socket manager goroutines for event monitoring
+	for _, sm := range dockerLoader.socketManagers {
+		if sm.client != nil {
+			// Already connected (default single-socket path) — just monitor events
+			go sm.monitorEvents()
+		} else {
+			// Not yet connected (multi-socket path) — run full lifecycle
+			go sm.run()
+		}
+	}
 
 	return nil
 }
 
-func (dockerLoader *DockerLoader) monitorEvents() {
-	for {
-		dockerLoader.listenEvents()
-		time.Sleep(30 * time.Second)
-	}
-}
-
-func (dockerLoader *DockerLoader) listenEvents() {
-	args := filters.NewArgs()
-	if !isTrue.MatchString(os.Getenv("CADDY_DOCKER_NO_SCOPE")) {
-		// This env var is useful for Podman where in some instances the scope can cause some issues.
-		args.Add("scope", "swarm")
-		args.Add("scope", "local")
-	}
-	args.Add("type", "service")
-	args.Add("type", "container")
-	args.Add("type", "config")
-	args.Add("type", "network")
-
-	for i, dockerClient := range dockerLoader.dockerClients {
-		context, cancel := context.WithCancel(context.Background())
-
-		eventsChan, errorChan := dockerClient.Events(context, events.ListOptions{
-			Filters: args,
-		})
-
-		log := logger()
-		log.Info("Connecting to docker events", zap.String("DockerSocket", dockerLoader.options.DockerSockets[i]))
-
-	ListenEvents:
-		for {
-			select {
-			case event := <-eventsChan:
-				if dockerLoader.skipEvents[i] {
-					continue
-				}
-
-				update := (event.Type == "container" && event.Action == "create") ||
-					(event.Type == "container" && event.Action == "start") ||
-					(event.Type == "container" && event.Action == "stop") ||
-					(event.Type == "container" && event.Action == "die") ||
-					(event.Type == "container" && event.Action == "destroy") ||
-					(event.Type == "service" && event.Action == "create") ||
-					(event.Type == "service" && event.Action == "update") ||
-					(event.Type == "service" && event.Action == "remove") ||
-					(event.Type == "config" && event.Action == "create") ||
-					(event.Type == "config" && event.Action == "remove") ||
-					(event.Type == "network" && event.Action == "connect") ||
-					(event.Type == "network" && event.Action == "disconnect")
-
-				if update {
-					dockerLoader.skipEvents[i] = true
-					dockerLoader.timer.Reset(dockerLoader.options.EventThrottleInterval)
-				}
-			case err := <-errorChan:
-				cancel()
-				if err != nil {
-					log.Error("Docker events error", zap.Error(err))
-				}
-				break ListenEvents
-			}
-		}
-	}
-}
-
 func (dockerLoader *DockerLoader) update() bool {
 	dockerLoader.timer.Reset(dockerLoader.options.PollingInterval)
-	for i := 0; i < len(dockerLoader.skipEvents); i++ {
-		dockerLoader.skipEvents[i] = false
+	for _, sm := range dockerLoader.socketManagers {
+		sm.skipEvents = false
 	}
 
 	// Don't cache the logger more globally, it can change based on config reloads

--- a/socket_manager.go
+++ b/socket_manager.go
@@ -1,0 +1,201 @@
+package caddydockerproxy
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/docker"
+
+	"go.uber.org/zap"
+)
+
+// connectFn is a function that creates and pings a docker client.
+// Returns the connected client or an error.
+type connectFn func() (docker.Client, error)
+
+type socketManager struct {
+	socket     string
+	certsPath  string
+	apiVersion string
+	retryMin   time.Duration
+	retryMax   time.Duration
+
+	connectFn  connectFn
+	client     docker.Client
+	skipEvents bool
+
+	loader *DockerLoader
+}
+
+// newSocketManager creates a socket manager for the given socket address.
+func newSocketManager(socket, certsPath, apiVersion string, retryMin, retryMax time.Duration, loader *DockerLoader) *socketManager {
+	sm := &socketManager{
+		socket:     socket,
+		certsPath:  certsPath,
+		apiVersion: apiVersion,
+		retryMin:   retryMin,
+		retryMax:   retryMax,
+		loader:     loader,
+	}
+	sm.connectFn = sm.defaultConnect
+	return sm
+}
+
+// defaultConnect creates a docker client using explicit options (no env vars).
+func (sm *socketManager) defaultConnect() (docker.Client, error) {
+	opts := []client.Opt{
+		client.WithHost(sm.socket),
+		client.WithAPIVersionNegotiation(),
+	}
+
+	if sm.certsPath != "" {
+		opts = append(opts, client.WithTLSClientConfig(
+			sm.certsPath+"/ca.pem",
+			sm.certsPath+"/cert.pem",
+			sm.certsPath+"/key.pem",
+		))
+	}
+
+	if sm.apiVersion != "" {
+		opts = append(opts, client.WithVersion(sm.apiVersion))
+	}
+
+	dockerClient, err := client.NewClientWithOpts(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = dockerClient.Ping(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return docker.WrapClient(dockerClient), nil
+}
+
+// attemptConnect tries to connect once. Returns the client (or nil) and the
+// backoff duration to use before the next attempt.
+func (sm *socketManager) attemptConnect() (docker.Client, time.Duration) {
+	log := logger()
+
+	c, err := sm.connectFn()
+	if err != nil {
+		log.Warn("Docker socket unavailable, will retry",
+			zap.String("socket", sm.socket),
+			zap.Error(err),
+		)
+		return nil, sm.retryMin
+	}
+
+	log.Info("Docker socket connected", zap.String("socket", sm.socket))
+	return c, sm.retryMin
+}
+
+// nextBackoff doubles the current backoff, capped at retryMax.
+func (sm *socketManager) nextBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > sm.retryMax {
+		next = sm.retryMax
+	}
+	return next
+}
+
+// run is the main lifecycle goroutine for this socket.
+// It loops forever: connect -> listen for events -> on error, disconnect and retry.
+func (sm *socketManager) run() {
+	log := logger()
+	backoff := sm.retryMin
+
+	for {
+		// Connect phase
+		c, _ := sm.attemptConnect()
+		if c == nil {
+			time.Sleep(backoff)
+			backoff = sm.nextBackoff(backoff)
+			continue
+		}
+
+		// Connected — reset backoff and register
+		backoff = sm.retryMin
+		sm.loader.setClient(sm, c)
+		sm.loader.triggerUpdate()
+
+		// Event listening phase
+		sm.listenEvents(c)
+
+		// Disconnected — remove client and trigger regeneration
+		log.Warn("Docker socket disconnected", zap.String("socket", sm.socket))
+		sm.loader.setClient(sm, nil)
+		sm.loader.triggerUpdate()
+	}
+}
+
+// monitorEvents is used for sockets that are already connected at startup
+// (the default single-socket path). It just listens for events and reconnects
+// on error.
+func (sm *socketManager) monitorEvents() {
+	for {
+		sm.listenEvents(sm.client)
+		time.Sleep(30 * time.Second)
+	}
+}
+
+// listenEvents listens for docker events on this socket's client.
+// Returns when the event stream errors (indicating disconnection).
+func (sm *socketManager) listenEvents(dockerClient docker.Client) {
+	args := filters.NewArgs()
+	if !isTrue.MatchString(os.Getenv("CADDY_DOCKER_NO_SCOPE")) {
+		args.Add("scope", "swarm")
+		args.Add("scope", "local")
+	}
+	args.Add("type", "service")
+	args.Add("type", "container")
+	args.Add("type", "config")
+	args.Add("type", "network")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	eventsChan, errorChan := dockerClient.Events(ctx, events.ListOptions{
+		Filters: args,
+	})
+
+	log := logger()
+	log.Info("Listening for docker events", zap.String("socket", sm.socket))
+
+	for {
+		select {
+		case event := <-eventsChan:
+			if sm.skipEvents {
+				continue
+			}
+
+			update := (event.Type == "container" && event.Action == "create") ||
+				(event.Type == "container" && event.Action == "start") ||
+				(event.Type == "container" && event.Action == "stop") ||
+				(event.Type == "container" && event.Action == "die") ||
+				(event.Type == "container" && event.Action == "destroy") ||
+				(event.Type == "service" && event.Action == "create") ||
+				(event.Type == "service" && event.Action == "update") ||
+				(event.Type == "service" && event.Action == "remove") ||
+				(event.Type == "config" && event.Action == "create") ||
+				(event.Type == "config" && event.Action == "remove") ||
+				(event.Type == "network" && event.Action == "connect") ||
+				(event.Type == "network" && event.Action == "disconnect")
+
+			if update {
+				sm.skipEvents = true
+				sm.loader.triggerThrottledUpdate()
+			}
+		case err := <-errorChan:
+			if err != nil {
+				log.Error("Docker events error", zap.String("socket", sm.socket), zap.Error(err))
+			}
+			return
+		}
+	}
+}

--- a/socket_manager_test.go
+++ b/socket_manager_test.go
@@ -1,0 +1,129 @@
+package caddydockerproxy
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/docker"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockDockerClientFactory tracks connection attempts
+type mockDockerClientFactory struct {
+	mu        sync.Mutex
+	attempts  int
+	failUntil int
+	client    docker.Client
+}
+
+func (f *mockDockerClientFactory) connect() (docker.Client, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts++
+	if f.attempts <= f.failUntil {
+		return nil, assert.AnError
+	}
+	return f.client, nil
+}
+
+func (f *mockDockerClientFactory) getAttempts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+func TestSocketManagerConnectsSuccessfully(t *testing.T) {
+	mockClient := &docker.ClientMock{}
+	factory := &mockDockerClientFactory{client: mockClient, failUntil: 0}
+
+	sm := &socketManager{
+		socket:    "unix:///var/run/docker.sock",
+		retryMin:  10 * time.Millisecond,
+		retryMax:  100 * time.Millisecond,
+		connectFn: factory.connect,
+	}
+
+	client, backoff := sm.attemptConnect()
+	assert.NotNil(t, client)
+	assert.Equal(t, sm.retryMin, backoff)
+	assert.Equal(t, 1, factory.getAttempts())
+}
+
+func TestSocketManagerConnectReturnsNilOnFailure(t *testing.T) {
+	factory := &mockDockerClientFactory{failUntil: 10}
+
+	sm := &socketManager{
+		socket:    "unix:///var/run/docker.sock",
+		retryMin:  10 * time.Millisecond,
+		retryMax:  100 * time.Millisecond,
+		connectFn: factory.connect,
+	}
+
+	client, backoff := sm.attemptConnect()
+	assert.Nil(t, client)
+	assert.Equal(t, sm.retryMin, backoff)
+	assert.Equal(t, 1, factory.getAttempts())
+}
+
+func TestSocketManagerBackoffDoublesOnFailure(t *testing.T) {
+	sm := &socketManager{
+		socket:   "unix:///var/run/docker.sock",
+		retryMin: 10 * time.Millisecond,
+		retryMax: 100 * time.Millisecond,
+	}
+
+	backoff := sm.retryMin
+	backoff = sm.nextBackoff(backoff)
+	assert.Equal(t, 20*time.Millisecond, backoff)
+
+	backoff = sm.nextBackoff(backoff)
+	assert.Equal(t, 40*time.Millisecond, backoff)
+
+	backoff = sm.nextBackoff(backoff)
+	assert.Equal(t, 80*time.Millisecond, backoff)
+
+	// Should cap at retryMax
+	backoff = sm.nextBackoff(backoff)
+	assert.Equal(t, 100*time.Millisecond, backoff)
+
+	// Should stay at retryMax
+	backoff = sm.nextBackoff(backoff)
+	assert.Equal(t, 100*time.Millisecond, backoff)
+}
+
+func TestDockerLoaderGetConnectedClients(t *testing.T) {
+	loader := &DockerLoader{
+		options:         &config.Options{},
+		serversVersions: utils.NewStringInt64CMap(),
+		serversUpdating: utils.NewStringBoolCMap(),
+	}
+
+	mockClient1 := &docker.ClientMock{}
+	mockClient2 := &docker.ClientMock{}
+
+	sm1 := &socketManager{client: mockClient1}
+	sm2 := &socketManager{client: nil} // disconnected
+	sm3 := &socketManager{client: mockClient2}
+
+	loader.socketManagers = []*socketManager{sm1, sm2, sm3}
+
+	clients := loader.getConnectedClients()
+	assert.Len(t, clients, 2)
+	assert.Equal(t, mockClient1, clients[0])
+	assert.Equal(t, mockClient2, clients[1])
+}
+
+func TestDockerLoaderGetConnectedClientsEmpty(t *testing.T) {
+	loader := &DockerLoader{
+		options:         &config.Options{},
+		serversVersions: utils.NewStringInt64CMap(),
+		serversUpdating: utils.NewStringBoolCMap(),
+	}
+	loader.socketManagers = []*socketManager{}
+
+	clients := loader.getConnectedClients()
+	assert.Len(t, clients, 0)
+}


### PR DESCRIPTION
## Summary
  - When `--docker-sockets` is configured with multiple sockets, each is now optional: a failed connection logs a warning and retries with exponential backoff instead of aborting startup.
  - Routes appear once a socket connects and are removed from the Caddyfile on the next regeneration if that socket drops.
  - New `--docker-retry-min` (default `1s`) and `--docker-retry-max` (default `30s`) control the backoff bounds. Available as `CADDY_DOCKER_RETRY_MIN` / `CADDY_DOCKER_RETRY_MAX`.
  - The single-socket default is unchanged — one unreachable socket is still a fatal startup error.