### PR TITLE
ci: stabilize docker tests and bump deprecated actions

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.4
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build
         run: |
@@ -31,7 +31,7 @@ jobs:
         shell: bash
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: binaries
           path: ${{ runner.temp }}/artifacts/binaries
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: binaries
           path: artifacts/binaries
@@ -68,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: binaries
           path: artifacts/binaries

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,14 +2,26 @@
 
 set -e
 
+wait_stack_removed() {
+  for _ in $(seq 1 30); do
+    remaining=$(docker network ls --filter label=com.docker.stack.namespace=caddy_test -q)
+    if [ -z "$remaining" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "warning: caddy_test stack networks still present after 30s" >&2
+}
+
 trap "exit 1" INT
-trap "docker stack rm caddy_test" EXIT
+trap "docker stack rm caddy_test; wait_stack_removed" EXIT
 
 docker network create --driver overlay --attachable caddy_test || true
 
 for d in */
 do
   docker stack rm caddy_test || true
+  wait_stack_removed
 
   echo ""
   echo ""


### PR DESCRIPTION
## Summary
- **tests/run.sh**: wait for the `caddy_test` stack's overlay networks to actually disappear before starting the next scenario. `docker stack rm` returns before the swarm finishes tearing down networks, which was causing flaky runs with `network internal not found` when the next scenario tried to create services (see failed master run [24550216117](https://github.com/lucaslorentz/caddy-docker-proxy/actions/runs/24550216117)).
- **ci-pipeline.yaml**: bump `actions/checkout`, `setup-go`, `upload-artifact`, `download-artifact` from `v4` → `v5` to run on Node.js 24 and clear the deprecation warnings GitHub has been emitting.

## Test plan
- [x] CI pipeline goes green on this branch
- [x] Re-run a few times to confirm the `standalone/` test no longer fails intermittently
- [x] No new warnings in the action setup steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)