### PR TITLE
fix: continue past per-client TaskList errors in multi-socket mode

### DIFF
--- a/docker/client_mock.go
+++ b/docker/client_mock.go
@@ -17,6 +17,7 @@ type ClientMock struct {
 	ServicesData         []swarm.Service
 	ConfigsData          []swarm.Config
 	TasksData            []swarm.Task
+	TaskListErr          error
 	NetworksData         []network.Summary
 	InfoData             system.Info
 	ContainerInspectData map[string]types.ContainerJSON
@@ -37,6 +38,9 @@ func (mock *ClientMock) ServiceList(ctx context.Context, options types.ServiceLi
 
 // TaskList list all tasks
 func (mock *ClientMock) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	if mock.TaskListErr != nil {
+		return nil, mock.TaskListErr
+	}
 	matchingTasks := []swarm.Task{}
 	for _, task := range mock.TasksData {
 		if !options.Filters.Match("service", task.ServiceID) {

--- a/generator/services.go
+++ b/generator/services.go
@@ -60,7 +60,8 @@ func (g *CaddyfileGenerator) getServiceTasksIps(service *swarm.Service, logger *
 	for _, dockerClient := range g.dockerClients {
 		tasks, err := dockerClient.TaskList(context.Background(), types.TaskListOptions{Filters: taskListFilter})
 		if err != nil {
-			return []string{}, err
+			logger.Debug("Failed to get Swarm tasks from docker client, skipping", zap.String("service", service.Spec.Name), zap.Error(err))
+			continue
 		}
 
 		for _, task := range tasks {

--- a/generator/services_test.go
+++ b/generator/services_test.go
@@ -1,12 +1,19 @@
 package generator
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/docker"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestServices_TemplateData(t *testing.T) {
@@ -520,4 +527,83 @@ func TestServiceTasks_Running(t *testing.T) {
 	testGeneration(t, dockerClient, func(options *config.Options) {
 		options.ProxyServiceTasks = true
 	}, expectedCaddyfile, expectedLogs)
+}
+
+// TestServiceTasks_OneClientTaskListError verifies that when running in
+// multi-socket mode and one of the docker clients returns an error from
+// TaskList (e.g. a Swarm worker responding "This node is not a swarm
+// manager"), the generator continues to collect tasks from the remaining
+// healthy clients instead of dropping the service's upstreams entirely.
+//
+// Regression test for #801 / fix for the pre-existing fail-fast in
+// getServiceTasksIps that was carried over from the single-client era in
+// PR #303 without adapting the error semantics for the multi-client loop.
+func TestServiceTasks_OneClientTaskListError(t *testing.T) {
+	managerClient := createBasicDockerClientMock()
+	managerClient.ServicesData = []swarm.Service{
+		{
+			ID: "SERVICEID",
+			Spec: swarm.ServiceSpec{
+				Annotations: swarm.Annotations{
+					Name: "service",
+					Labels: map[string]string{
+						fmtLabel("%s"):               "service.testdomain.com",
+						fmtLabel("%s.reverse_proxy"): "{{upstreams 5000}}",
+					},
+				},
+			},
+			Endpoint: swarm.Endpoint{
+				VirtualIPs: []swarm.EndpointVirtualIP{
+					{NetworkID: caddyNetworkID},
+				},
+			},
+		},
+	}
+	managerClient.TasksData = []swarm.Task{
+		{
+			ServiceID: "SERVICEID",
+			NetworksAttachments: []swarm.NetworkAttachment{
+				{
+					Network:   swarm.Network{ID: caddyNetworkID},
+					Addresses: []string{"10.0.0.1/24"},
+				},
+			},
+			DesiredState: swarm.TaskStateRunning,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+		},
+	}
+
+	// Second client behaves like a Swarm worker: TaskList returns the
+	// "not a swarm manager" error that real workers return.
+	workerClient := createBasicDockerClientMock()
+	workerClient.TaskListErr = errors.New("Error response from daemon: This node is not a swarm manager.")
+
+	options := &config.Options{
+		LabelPrefix:       DefaultLabelPrefix,
+		ProxyServiceTasks: true,
+	}
+
+	dockerUtils := createDockerUtilsMock()
+	generator := CreateGenerator(
+		[]docker.Client{managerClient, workerClient},
+		dockerUtils,
+		options,
+	)
+
+	var logsBuffer bytes.Buffer
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	encoderConfig.TimeKey = ""
+	encoder := zapcore.NewConsoleEncoder(encoderConfig)
+	writer := bufio.NewWriter(&logsBuffer)
+	logger := zap.New(zapcore.NewCore(encoder, zapcore.AddSync(writer), zapcore.InfoLevel))
+
+	caddyfileBytes, _ := generator.GenerateCaddyfile(logger)
+	writer.Flush()
+
+	const expectedCaddyfile = "service.testdomain.com {\n" +
+		"	reverse_proxy 10.0.0.1:5000\n" +
+		"}\n"
+
+	assert.Equal(t, expectedCaddyfile, string(caddyfileBytes),
+		"manager client's task IP must still reach the Caddyfile when a peer client's TaskList errors")
 }


### PR DESCRIPTION
Fixes #801.

## Summary

In multi-socket mode (`--docker-sockets a,b,c`), `getServiceTasksIps` had a single-client-era fail-fast — any docker client whose `TaskList` errored aborted the entire upstream-discovery call. The most common trigger in practice is including a Swarm worker socket in the list: the worker returns `This node is not a swarm manager`, the function returns `[]string{}, err`, the calling `getServiceCaddyfile` propagates the error up, and `generator.go:172` drops the **entire service site block** from the Caddyfile.

This patch aligns the loop with the other multi-client loops in the same generator (`ServiceList` at `generator.go:175`, `ConfigList` at `generator.go:113`, `ContainerList` at `generator.go:143`), which all swallow per-client errors to a log line and continue. The manager socket's tasks still reach the Caddyfile; the worker socket's failure becomes a debug log.

## Production validation

This was found while debugging a Swarm cluster where enabling multi-socket mode caused **12 of 31 caddy sites to disappear instantly**. With this patch applied, all 31 sites are correctly generated. Verified end-to-end against a 4-node real swarm (1 manager + 3 workers, remote daemons bridged via socat-over-ssh):

| | Without patch | With patch |
|---|---|---|
| Caddy sites rendered | 19 / 31 | **31 / 31** |
| Multi-upstream services (e.g. health-checked replicas) | dropped | preserved |
| Behavior on the manager-only socket | unchanged | unchanged |

Switching the running image between the two builds (3-line diff is the only difference) toggles the set deterministically; `curl` traffic on port 80 recovered within 5–10 s on each switch with no other errors.

## Changes

- `generator/services.go` — replace `return []string{}, err` with `logger.Debug(...); continue` inside the multi-client loop (3 lines).
- `docker/client_mock.go` — add `TaskListErr error` field for injecting per-client errors in tests (4 lines).
- `generator/services_test.go` — add `TestServiceTasks_OneClientTaskListError`: two `ClientMock` instances, one healthy and one returning the real `not a swarm manager` daemon error; asserts the healthy client's task IP still ends up in the rendered Caddyfile.

## Test verification

```
$ go test ./generator/...
ok      github.com/lucaslorentz/caddy-docker-proxy/v2/generator    0.033s

$ go test -race ./generator/...
ok      github.com/lucaslorentz/caddy-docker-proxy/v2/generator    1.132s
```

The new test reliably **fails** when reverting `services.go` alone (verified via `git stash`), so it's a true regression test rather than just exercising the new code path.

## Scope notes

- Orthogonal to #793 (sockets-optional / retry). #793 covers "socket unreachable"; this covers "socket reachable but not a Swarm manager". Both can coexist; merging order doesn't matter.
- No public API or option changes. Existing single-socket and homogeneous-manager-socket users see no behavior difference.
- One slight visibility change: the worker's "not a swarm manager" surfaces at debug level inside `services.go` rather than bubbling up to the existing `ERROR Failed to get Swarm service caddyfile` at `generator.go:172`. For users currently relying on that ERROR as a signal, the existing `ERROR Failed to get Swarm services` / `Failed to get Swarm configs` at the same call sites in `generator.go` are unchanged and still emitted once per poll.

---

*Disclosure: this fix was developed with Claude (Anthropic) running under my supervision — root-cause analysis, patch, regression test, and production validation against a real 4-node swarm. I've reviewed every line. — @boin*
