### PR TITLE
ci: work around Docker daemon not running on windows-2022 runners

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -81,6 +81,21 @@ jobs:
       #   run: .\run-docker-tests-windows.sh
       #   shell: bash
 
+      # Workaround for actions/runner-images#13729: the Docker daemon is
+      # frequently not running when the windows-2022 runner starts, causing
+      # `npipe:////./pipe/docker_engine` connection failures. Start the
+      # service and wait for it to become responsive before building.
+      - name: Ensure Docker is running (Windows)
+        shell: pwsh
+        run: |
+          Start-Service docker
+          for ($i = 0; $i -lt 30; $i++) {
+            docker info *> $null
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            Start-Sleep 2
+          }
+          docker info
+
       - name: Build Docker Images
         run: ./build-images-windows.sh
         env:


### PR DESCRIPTION
## Summary

**Workaround for the Windows CI job**, not a code fix.

The GitHub-hosted `windows-2022` (and `windows-2025`) runner images frequently start **without the Docker daemon running**, so `docker buildx` in the `Windows` job fails immediately with:

```
failed to connect to the docker API at npipe:////./pipe/docker_engine;
check if the path is correct and if the daemon is running
```

This is an **upstream, infra-side regression** on GitHub's hosted Windows runners (started ~Feb 2026) — not a problem with this repo's code or any specific commit. It's **intermittent**: the same commit passes on a runner where the daemon happens to be up and fails on one where it isn't (observed two master runs ~6 min apart, same runner image `win22/20260525.178`, one green / one red).

## Change

Adds a step before **Build Docker Images** in the `windows` job that explicitly starts the `docker` service and waits (up to ~60s) for it to respond, failing with a useful `docker info` if it never comes up.

```yaml
- name: Ensure Docker is running (Windows)
  shell: pwsh
  run: |
    Start-Service docker
    for ($i = 0; $i -lt 30; $i++) {
      docker info *> $null
      if ($LASTEXITCODE -eq 0) { exit 0 }
      Start-Sleep 2
    }
    docker info
```

Only touches `.github/workflows/ci-pipeline.yaml`. No effect on the Linux or build jobs.

## References

- actions/runner-images#13729 — *windows-2022: docker not available when runner starts* (open, acknowledged by maintainers)
- actions/runner-images#6688 — related Docker-on-Windows-runner issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)