### PR TITLE
feat: --log-level / --log-format for Caddy logging in all modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ Run `caddy help docker-proxy` to see the raw flag output.
 | `--scan-stopped-containers` | `CADDY_DOCKER_SCAN_STOPPED_CONTAINERS` | Scan stopped containers and use their labels.<br>**Default:** `false` |
 | `--polling-interval` | `CADDY_DOCKER_POLLING_INTERVAL` | Interval to manually check Docker for a new Caddyfile.<br>**Default:** `30s` |
 | `--event-throttle-interval` | `CADDY_DOCKER_EVENT_THROTTLE_INTERVAL` | Interval to throttle Caddyfile updates triggered by Docker events.<br>**Default:** `100ms` |
+| `--log-level` | `CADDY_DOCKER_LOG_LEVEL` | Log level: `DEBUG` \| `INFO` \| `WARN` \| `ERROR`. Empty keeps Caddy's default |
+| `--log-format` | `CADDY_DOCKER_LOG_FORMAT` | Log format: `console` \| `json`. Empty keeps Caddy's default |
 | _(env only)_ | `CADDY_ADMIN` | Override Caddy's admin listen address |
 | _(env only)_ | `CADDY_DOCKER_NO_SCOPE` | Disable Docker event scope filter (useful for Podman).<br>**Default:** `false` |
 

--- a/cmd.go
+++ b/cmd.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+	caddylogging "github.com/caddyserver/caddy/v2/modules/logging"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/generator"
 
@@ -70,6 +72,12 @@ func init() {
 			fs.Duration("event-throttle-interval", 100*time.Millisecond,
 				"Interval to throttle caddyfile updates triggered by docker events")
 
+			fs.String("log-level", "",
+				"Log level: DEBUG | INFO | WARN | ERROR. Applies in all modes. Empty keeps Caddy's default (INFO)")
+
+			fs.String("log-format", "",
+				"Log format: console | json. Applies in all modes. Empty keeps Caddy's default")
+
 			return fs
 		}(),
 	})
@@ -79,23 +87,17 @@ func cmdFunc(flags caddycmd.Flags) (int, error) {
 	caddy.TrapSignals()
 
 	options := createOptions(flags)
-	log := logger()
+
+	if err := caddy.Run(buildCaddyRunConfig(options)); err != nil {
+		return 1, err
+	}
 
 	if options.Mode&config.Server == config.Server {
-		log.Info("Running caddy proxy server")
-
-		err := caddy.Run(&caddy.Config{
-			Admin: &caddy.AdminConfig{
-				Listen: getAdminListen(options),
-			},
-		})
-		if err != nil {
-			return 1, err
-		}
+		logger().Info("Running caddy proxy server")
 	}
 
 	if options.Mode&config.Controller == config.Controller {
-		log.Info("Running caddy proxy controller")
+		logger().Info("Running caddy proxy controller")
 		loader := CreateDockerLoader(options)
 		if err := loader.Start(); err != nil {
 			if err := caddy.Stop(); err != nil {
@@ -107,6 +109,51 @@ func cmdFunc(flags caddycmd.Flags) (int, error) {
 	}
 
 	select {}
+}
+
+// buildCaddyRunConfig builds the Caddy config to run: the admin config plus the
+// configured logging.
+func buildCaddyRunConfig(options *config.Options) *caddy.Config {
+	return &caddy.Config{
+		Admin:   buildCaddyAdminConfig(options),
+		Logging: buildCaddyLoggingConfig(options),
+	}
+}
+
+// buildCaddyAdminConfig builds Caddy's admin config: controller-only mode
+// doesn't serve anything, so its admin endpoint is disabled; server/standalone
+// exposes the admin endpoint used to load configs.
+func buildCaddyAdminConfig(options *config.Options) *caddy.AdminConfig {
+	if options.Mode&config.Server != config.Server {
+		return &caddy.AdminConfig{Disabled: true}
+	}
+	return &caddy.AdminConfig{Listen: getAdminListen(options)}
+}
+
+// buildCaddyLoggingConfig builds Caddy's logging config from the configured
+// log level/format. Unset values are left empty so Caddy applies its own
+// defaults.
+func buildCaddyLoggingConfig(options *config.Options) *caddy.Logging {
+	defaultLog := &caddy.CustomLog{}
+
+	if level := strings.ToUpper(strings.TrimSpace(options.LogLevel)); level != "" {
+		defaultLog.Level = level
+	}
+	switch strings.ToLower(strings.TrimSpace(options.LogFormat)) {
+	case "console":
+		defaultLog.EncoderRaw = caddyconfig.JSONModuleObject(caddylogging.ConsoleEncoder{}, "format", "console", nil)
+	case "json":
+		defaultLog.EncoderRaw = caddyconfig.JSONModuleObject(caddylogging.JSONEncoder{}, "format", "json", nil)
+	}
+	// Controller-only mode runs Caddy with the admin endpoint disabled; drop the
+	// admin logger so Caddy doesn't warn that it's disabled on every start.
+	if options.Mode&config.Server != config.Server {
+		defaultLog.Exclude = append(defaultLog.Exclude, "admin")
+	}
+
+	return &caddy.Logging{
+		Logs: map[string]*caddy.CustomLog{"default": defaultLog},
+	}
 }
 
 func getAdminListen(options *config.Options) string {
@@ -172,6 +219,8 @@ func createOptions(flags caddycmd.Flags) *config.Options {
 	dockerCertsPathFlag := flags.String("docker-certs-path")
 	dockerAPIsVersionFlag := flags.String("docker-apis-version")
 	ingressNetworksFlag := flags.String("ingress-networks")
+	logLevelFlag := flags.String("log-level")
+	logFormatFlag := flags.String("log-format")
 
 	options := &config.Options{}
 
@@ -295,6 +344,38 @@ func createOptions(flags caddycmd.Flags) *config.Options {
 		}
 	} else {
 		options.EventThrottleInterval = eventThrottleIntervalFlag
+	}
+
+	if logLevelEnv := os.Getenv("CADDY_DOCKER_LOG_LEVEL"); logLevelEnv != "" {
+		options.LogLevel = logLevelEnv
+	} else {
+		options.LogLevel = logLevelFlag
+	}
+
+	if logFormatEnv := os.Getenv("CADDY_DOCKER_LOG_FORMAT"); logFormatEnv != "" {
+		options.LogFormat = logFormatEnv
+	} else {
+		options.LogFormat = logFormatFlag
+	}
+
+	// Ignore an unrecognized log level/format instead of failing Caddy startup
+	// (level) or applying an empty logging config (format); matches how other
+	// invalid options fall back above.
+	if options.LogLevel != "" {
+		switch strings.ToLower(options.LogLevel) {
+		case "debug", "info", "warn", "error", "panic", "fatal":
+		default:
+			log.Error("Ignoring invalid log level", zap.String("log-level", options.LogLevel))
+			options.LogLevel = ""
+		}
+	}
+	if options.LogFormat != "" {
+		switch strings.ToLower(options.LogFormat) {
+		case "console", "json":
+		default:
+			log.Error("Ignoring invalid log format", zap.String("log-format", options.LogFormat))
+			options.LogFormat = ""
+		}
 	}
 
 	return options

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -49,3 +49,72 @@ func TestGetAdminListenPrefersConfiguredListen(t *testing.T) {
 
 	assert.Equal(t, "tcp/0.0.0.0:2019", getAdminListen(options))
 }
+
+func TestBuildCaddyLoggingConfig(t *testing.T) {
+	t.Run("empty default log when nothing customized (Caddy defaults apply)", func(t *testing.T) {
+		logging := buildCaddyLoggingConfig(&config.Options{Mode: config.Standalone})
+		assert.NotNil(t, logging)
+		dl := logging.Logs["default"]
+		assert.Empty(t, dl.Level)
+		assert.Nil(t, dl.EncoderRaw)
+		assert.Empty(t, dl.Exclude)
+	})
+
+	t.Run("sets default log level", func(t *testing.T) {
+		logging := buildCaddyLoggingConfig(&config.Options{Mode: config.Standalone, LogLevel: "error"})
+		assert.NotNil(t, logging)
+		assert.Equal(t, "ERROR", logging.Logs["default"].Level)
+		assert.Nil(t, logging.Logs["default"].EncoderRaw)
+		assert.Empty(t, logging.Logs["default"].Exclude)
+	})
+
+	t.Run("sets console encoder", func(t *testing.T) {
+		logging := buildCaddyLoggingConfig(&config.Options{Mode: config.Standalone, LogFormat: "console"})
+		assert.NotNil(t, logging)
+		assert.JSONEq(t, `{"format":"console"}`, string(logging.Logs["default"].EncoderRaw))
+	})
+
+	t.Run("sets json encoder and level together", func(t *testing.T) {
+		logging := buildCaddyLoggingConfig(&config.Options{Mode: config.Standalone, LogLevel: "WARN", LogFormat: "json"})
+		assert.NotNil(t, logging)
+		assert.Equal(t, "WARN", logging.Logs["default"].Level)
+		assert.JSONEq(t, `{"format":"json"}`, string(logging.Logs["default"].EncoderRaw))
+	})
+
+	t.Run("controller-only excludes the admin logger", func(t *testing.T) {
+		logging := buildCaddyLoggingConfig(&config.Options{Mode: config.Controller, LogLevel: "error"})
+		assert.NotNil(t, logging)
+		assert.Contains(t, logging.Logs["default"].Exclude, "admin")
+	})
+}
+
+func TestBuildCaddyRunConfig(t *testing.T) {
+	t.Run("server/standalone uses the admin endpoint", func(t *testing.T) {
+		cfg := buildCaddyRunConfig(&config.Options{Mode: config.Standalone})
+		assert.NotNil(t, cfg)
+		assert.NotNil(t, cfg.Admin)
+		assert.False(t, cfg.Admin.Disabled)
+		assert.Equal(t, "tcp/localhost:2019", cfg.Admin.Listen)
+	})
+
+	t.Run("controller-only disables admin and excludes admin logs", func(t *testing.T) {
+		cfg := buildCaddyRunConfig(&config.Options{Mode: config.Controller, LogLevel: "ERROR"})
+		assert.NotNil(t, cfg)
+		assert.NotNil(t, cfg.Admin)
+		assert.True(t, cfg.Admin.Disabled)
+		assert.Equal(t, "ERROR", cfg.Logging.Logs["default"].Level)
+		assert.Contains(t, cfg.Logging.Logs["default"].Exclude, "admin")
+	})
+}
+
+func TestBuildCaddyAdminConfig(t *testing.T) {
+	t.Run("server/standalone listens", func(t *testing.T) {
+		admin := buildCaddyAdminConfig(&config.Options{Mode: config.Standalone})
+		assert.False(t, admin.Disabled)
+		assert.Equal(t, "tcp/localhost:2019", admin.Listen)
+	})
+
+	t.Run("controller-only disables admin", func(t *testing.T) {
+		assert.True(t, buildCaddyAdminConfig(&config.Options{Mode: config.Controller}).Disabled)
+	})
+}

--- a/config/options.go
+++ b/config/options.go
@@ -24,6 +24,13 @@ type Options struct {
 	Secret                 string
 	ControllerNetwork      *net.IPNet
 	IngressNetworks        []string
+
+	// LogLevel and LogFormat configure Caddy's logging (level and encoder).
+	// They apply in all modes — including controller mode, via a minimal
+	// logging-only Caddy instance — and are re-applied on every pushed config
+	// so they survive reloads. Empty values keep Caddy's defaults.
+	LogLevel  string
+	LogFormat string
 }
 
 // Mode represents how this instance should run

--- a/loader.go
+++ b/loader.go
@@ -42,6 +42,7 @@ type DockerLoader struct {
 	lastVersion     int64
 	serversVersions *utils.StringInt64CMap
 	serversUpdating *utils.StringBoolCMap
+	caddyLogging    *caddy.Logging
 }
 
 // CreateDockerLoader creates a docker loader
@@ -50,12 +51,12 @@ func CreateDockerLoader(options *config.Options) *DockerLoader {
 		options:         options,
 		serversVersions: utils.NewStringInt64CMap(),
 		serversUpdating: utils.NewStringBoolCMap(),
+		caddyLogging:    buildCaddyLoggingConfig(options),
 	}
 }
 
 func logger() *zap.Logger {
-	return caddy.Log().
-		Named("docker-proxy")
+	return caddy.Log().Named("docker-proxy")
 }
 
 // Start docker loader
@@ -253,7 +254,7 @@ func (dockerLoader *DockerLoader) update() bool {
 	dockerLoader.lastCaddyfile = caddyfile
 
 	if caddyfileChanged {
-		log.Info("New Caddyfile", zap.ByteString("caddyfile", caddyfile))
+		log.Debug("New Caddyfile", zap.ByteString("caddyfile", caddyfile))
 
         tmpPath := CaddyfileAutosavePath + ".tmp"
         if err := os.WriteFile(tmpPath, caddyfile, 0640); err != nil {
@@ -275,7 +276,7 @@ func (dockerLoader *DockerLoader) update() bool {
 			return false
 		}
 
-		log.Info("New Config JSON", zap.ByteString("json", configJSON))
+		log.Debug("New Config JSON", zap.ByteString("json", configJSON))
 
 		dockerLoader.lastJSONConfig = configJSON
 		dockerLoader.lastVersion++
@@ -315,9 +316,9 @@ func (dockerLoader *DockerLoader) updateServer(wg *sync.WaitGroup, server string
 
 	url := "http://" + server + ":2019/load"
 
-	postBody, err := addAdminListen(dockerLoader.lastJSONConfig, getServerAdminListen(dockerLoader.options, server))
+	postBody, err := dockerLoader.prepareServerConfig(server)
 	if err != nil {
-		log.Error("Failed to add admin listen to", zap.String("server", server), zap.Error(err))
+		log.Error("Failed to prepare configuration for", zap.String("server", server), zap.Error(err))
 		return
 	}
 
@@ -350,20 +351,28 @@ func (dockerLoader *DockerLoader) updateServer(wg *sync.WaitGroup, server string
 	log.Info("Successfully configured", zap.String("server", server))
 }
 
-func addAdminListen(configJSON []byte, listen string) ([]byte, error) {
+// prepareServerConfig builds the config to push to server from the loader's last
+// generated config, with a single unmarshal/marshal round-trip.
+func (dockerLoader *DockerLoader) prepareServerConfig(server string) ([]byte, error) {
 	config := &caddy.Config{}
-	err := json.Unmarshal(configJSON, config)
-	if err != nil {
+	if err := json.Unmarshal(dockerLoader.lastJSONConfig, config); err != nil {
 		return nil, err
 	}
-	// Respect explicit admin settings from Caddyfile/JSON config,
-	// but override "admin off" since the plugin requires the admin API.
-	if config.Admin != nil && !config.Admin.Disabled {
-		return configJSON, nil
+
+	// Respect an explicit admin endpoint, but override "admin off" since the
+	// plugin requires the admin API.
+	if config.Admin == nil || config.Admin.Disabled {
+		config.Admin = &caddy.AdminConfig{Listen: getServerAdminListen(dockerLoader.options, server)}
 	}
-	config.Admin = &caddy.AdminConfig{
-		Listen: listen,
+
+	// Re-apply our logging only to the local Caddy (the standalone self-push),
+	// so --log-level/--log-format survive its config reload. Remote servers run
+	// their own instance and manage their own logging. Logging already defined
+	// in the config (e.g. via labels) is respected.
+	if server == "localhost" && dockerLoader.caddyLogging != nil && (config.Logging == nil || len(config.Logging.Logs) == 0) {
+		config.Logging = dockerLoader.caddyLogging
 	}
+
 	return json.Marshal(config)
 }
 

--- a/loader_test.go
+++ b/loader_test.go
@@ -10,58 +10,79 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddAdminListenAddsFallbackWhenMissing(t *testing.T) {
-	input, err := json.Marshal(&caddy.Config{})
-	require.NoError(t, err)
-
-	output, err := addAdminListen(input, "tcp/localhost:2019")
-	require.NoError(t, err)
-
-	result := &caddy.Config{}
-	err = json.Unmarshal(output, result)
-	require.NoError(t, err)
-	require.NotNil(t, result.Admin)
-	assert.Equal(t, "tcp/localhost:2019", result.Admin.Listen)
-}
-
-func TestAddAdminListenKeepsExistingAdminListen(t *testing.T) {
-	input, err := json.Marshal(&caddy.Config{
-		Admin: &caddy.AdminConfig{
-			Listen: "tcp/0.0.0.0:2019",
-		},
-	})
-	require.NoError(t, err)
-
-	output, err := addAdminListen(input, "tcp/localhost:2019")
-	require.NoError(t, err)
-
-	result := &caddy.Config{}
-	err = json.Unmarshal(output, result)
-	require.NoError(t, err)
-	require.NotNil(t, result.Admin)
-	assert.Equal(t, "tcp/0.0.0.0:2019", result.Admin.Listen)
-}
-
-func TestAddAdminListenOverridesAdminOff(t *testing.T) {
-	input, err := json.Marshal(&caddy.Config{
-		Admin: &caddy.AdminConfig{
-			Disabled: true,
-		},
-	})
-	require.NoError(t, err)
-
-	output, err := addAdminListen(input, "tcp/localhost:2019")
-	require.NoError(t, err)
-
-	result := &caddy.Config{}
-	err = json.Unmarshal(output, result)
-	require.NoError(t, err)
-	require.NotNil(t, result.Admin)
-	assert.False(t, result.Admin.Disabled)
-	assert.Equal(t, "tcp/localhost:2019", result.Admin.Listen)
-}
-
 func TestGetServerAdminListen(t *testing.T) {
 	assert.Equal(t, "tcp/10.0.0.2:2019", getServerAdminListen(&config.Options{}, "10.0.0.2"))
 	assert.Equal(t, "tcp/0.0.0.0:2019", getServerAdminListen(&config.Options{AdminListen: "tcp/0.0.0.0:2019"}, "10.0.0.2"))
+}
+
+func unmarshalConfig(t *testing.T, data []byte) *caddy.Config {
+	t.Helper()
+	config := &caddy.Config{}
+	require.NoError(t, json.Unmarshal(data, config))
+	return config
+}
+
+func TestPrepareServerConfig(t *testing.T) {
+	empty, err := json.Marshal(&caddy.Config{})
+	require.NoError(t, err)
+
+	loggingERROR := buildCaddyLoggingConfig(&config.Options{Mode: config.Standalone, LogLevel: "ERROR"})
+
+	newLoader := func(configJSON []byte, logging *caddy.Logging) *DockerLoader {
+		return &DockerLoader{options: &config.Options{}, lastJSONConfig: configJSON, caddyLogging: logging}
+	}
+
+	t.Run("adds admin listen fallback when missing", func(t *testing.T) {
+		out, err := newLoader(empty, nil).prepareServerConfig("10.0.0.2")
+		require.NoError(t, err)
+		assert.Equal(t, "tcp/10.0.0.2:2019", unmarshalConfig(t, out).Admin.Listen)
+	})
+
+	t.Run("keeps an explicit admin listen", func(t *testing.T) {
+		in, err := json.Marshal(&caddy.Config{Admin: &caddy.AdminConfig{Listen: "tcp/0.0.0.0:2019"}})
+		require.NoError(t, err)
+		out, err := newLoader(in, nil).prepareServerConfig("10.0.0.2")
+		require.NoError(t, err)
+		assert.Equal(t, "tcp/0.0.0.0:2019", unmarshalConfig(t, out).Admin.Listen)
+	})
+
+	t.Run("overrides admin off", func(t *testing.T) {
+		in, err := json.Marshal(&caddy.Config{Admin: &caddy.AdminConfig{Disabled: true}})
+		require.NoError(t, err)
+		out, err := newLoader(in, nil).prepareServerConfig("localhost")
+		require.NoError(t, err)
+		result := unmarshalConfig(t, out)
+		assert.False(t, result.Admin.Disabled)
+		assert.Equal(t, "tcp/localhost:2019", result.Admin.Listen)
+	})
+
+	t.Run("injects logging on the local Caddy", func(t *testing.T) {
+		out, err := newLoader(empty, loggingERROR).prepareServerConfig("localhost")
+		require.NoError(t, err)
+		result := unmarshalConfig(t, out)
+		require.NotNil(t, result.Logging)
+		assert.Equal(t, "ERROR", result.Logging.Logs["default"].Level)
+	})
+
+	t.Run("does not inject logging on remote servers", func(t *testing.T) {
+		out, err := newLoader(empty, loggingERROR).prepareServerConfig("10.0.0.2")
+		require.NoError(t, err)
+		assert.Nil(t, unmarshalConfig(t, out).Logging)
+	})
+
+	t.Run("no logging configured leaves logging unset", func(t *testing.T) {
+		out, err := newLoader(empty, nil).prepareServerConfig("localhost")
+		require.NoError(t, err)
+		assert.Nil(t, unmarshalConfig(t, out).Logging)
+	})
+
+	t.Run("respects logging already in the config", func(t *testing.T) {
+		in, err := json.Marshal(&caddy.Config{
+			Logging: &caddy.Logging{Logs: map[string]*caddy.CustomLog{"default": {BaseLog: caddy.BaseLog{Level: "WARN"}}}},
+		})
+		require.NoError(t, err)
+		out, err := newLoader(in, loggingERROR).prepareServerConfig("localhost")
+		require.NoError(t, err)
+		assert.Equal(t, "WARN", unmarshalConfig(t, out).Logging.Logs["default"].Level)
+	})
 }

--- a/log_integration_test.go
+++ b/log_integration_test.go
@@ -1,0 +1,28 @@
+package caddydockerproxy
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+// Verifies that the logging config produced from --log-level/--log-format is
+// accepted by caddy.Run and applied to caddy.Log(). This is also the exact path
+// used in controller-only mode (caddy.Run with admin disabled + logging).
+func TestIntegration_CaddyFollowsLogArgs(t *testing.T) {
+	cfg := &caddy.Config{
+		Admin:   &caddy.AdminConfig{Disabled: true},
+		Logging: buildCaddyLoggingConfig(&config.Options{LogLevel: "ERROR", LogFormat: "json"}),
+	}
+	require.NoError(t, caddy.Run(cfg))
+	t.Cleanup(func() { _ = caddy.Stop() })
+
+	core := caddy.Log().Core()
+	assert.False(t, core.Enabled(zapcore.InfoLevel), "INFO should be filtered after --log-level=ERROR")
+	assert.False(t, core.Enabled(zapcore.WarnLevel), "WARN should be filtered after --log-level=ERROR")
+	assert.True(t, core.Enabled(zapcore.ErrorLevel), "ERROR should pass")
+}


### PR DESCRIPTION
Fixes #794. Also addresses #266.

## Problem

The `docker-proxy` controller logs through `caddy.Log()`, but its level/format **can't be controlled via Caddy labels**:

- The controller starts Caddy with a bootstrap config that has **no `logging` section**.
- In `controller` mode, Caddy core is **never started locally** — the label-generated config goes to the server instances via the admin API.

So routine controller lines (`New Caddyfile`, `Process Caddyfile`, ...) flood the logs at the default **INFO** with no way to quiet them (the chicken-and-egg @francislavoie noted in #289 — they're emitted before/independently of the config the controller generates).

## Change

Add **`--log-level` / `CADDY_DOCKER_LOG_LEVEL`** and **`--log-format` / `CADDY_DOCKER_LOG_FORMAT`** that configure Caddy's logging in **all modes**:

- **standalone/server:** set on the Caddy config that already runs.
- **controller-only:** Caddy core runs as a minimal logging-only instance — **admin disabled, no apps, no listeners** (verified: 0 open ports) — so the flags take effect there too.
- In **standalone**, the logging is re-applied to the local Caddy on each `/load`, so the level/format survive its config reload (a `/load` with no logging resets it). Other controlled servers run their own instance and manage their own logging; logging defined via labels is respected.
- An unrecognized `--log-level` / `--log-format` is ignored (logged once) instead of failing startup, matching how other invalid options fall back.

**Defaults unchanged** (with neither flag set, Caddy's default logging applies), except two per-update full-content dumps (`New Caddyfile`, `New Config JSON`) demoted from `INFO` to `DEBUG` — the bulk of routine volume.

## Tests

- `TestBuildCaddyLoggingConfig` / `TestBuildCaddyAdminConfig` / `TestBuildCaddyRunConfig`: the config assembled per mode (admin endpoint vs disabled, level/encoder, admin logger excluded in controller-only).
- `TestPrepareServerConfig`: admin fallback/override, logging injected only on the local Caddy (not remote servers), labels respected.
- `TestIntegration_CaddyFollowsLogArgs`: `caddy.Run` with the built logging actually filters `caddy.Log()` by level (the controller-only path: admin disabled + logging).
- `go build` / `vet` / `test ./...` green, incl. `-race`.

Verified end-to-end with a real `xcaddy` build against a live Docker daemon (standalone + controller): level/format apply in all modes and persist across `/load` in standalone; controller-only shows **0 listeners**; invalid values fall back without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)