### PR TITLE
fix: create the autosave directory before writing the Caddyfile (#798)

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -256,12 +256,14 @@ func (dockerLoader *DockerLoader) update() bool {
 	if caddyfileChanged {
 		log.Debug("New Caddyfile", zap.ByteString("caddyfile", caddyfile))
 
-        tmpPath := CaddyfileAutosavePath + ".tmp"
-        if err := os.WriteFile(tmpPath, caddyfile, 0640); err != nil {
-            log.Warn("Failed to write temporary caddyfile", zap.Error(err), zap.String("path", tmpPath))
-        } else if err := os.Rename(tmpPath, CaddyfileAutosavePath); err != nil {
-            log.Warn("Failed to autosave caddyfile", zap.Error(err), zap.String("path", CaddyfileAutosavePath))
-        }
+		tmpPath := CaddyfileAutosavePath + ".tmp"
+		if err := os.MkdirAll(filepath.Dir(CaddyfileAutosavePath), 0700); err != nil {
+			log.Warn("Failed to create autosave directory", zap.Error(err), zap.String("path", filepath.Dir(CaddyfileAutosavePath)))
+		} else if err := os.WriteFile(tmpPath, caddyfile, 0640); err != nil {
+			log.Warn("Failed to write temporary caddyfile", zap.Error(err), zap.String("path", tmpPath))
+		} else if err := os.Rename(tmpPath, CaddyfileAutosavePath); err != nil {
+			log.Warn("Failed to autosave caddyfile", zap.Error(err), zap.String("path", CaddyfileAutosavePath))
+		}
 
 		adapter := caddyconfig.GetAdapter("caddyfile")
 


### PR DESCRIPTION
Fixes #798.

## Problem

In `controller` mode (reported in #798), and any setup where Caddy's config dir doesn't already exist, the autosaved Caddyfile write fails with a warning on **every** Caddyfile change:

```
WARN  docker-proxy  Failed to write temporary caddyfile
  error="open /config/caddy/Caddyfile.autosave.tmp: no such file or directory"
```

`CaddyfileAutosavePath` lives under `caddy.AppConfigDir()`, which is only created when Caddy persists its own config — that doesn't reliably happen in `controller` mode, so the directory is missing and the write fails (harmless, but logs a warning each cycle).

## Fix

`os.MkdirAll(filepath.Dir(CaddyfileAutosavePath), 0700)` before writing the autosave, so the plugin doesn't depend on Caddy having created the directory. Also normalizes that block's indentation from spaces to tabs.

## Verification

Reproduced with a real `xcaddy` build, `--mode=controller`, and a fresh `XDG_CONFIG_HOME` (so `AppConfigDir()` doesn't exist):

- **before:** `Failed to write temporary caddyfile` logged; dir not created.
- **after:** no warning; `<AppConfigDir>/Caddyfile.autosave` written.

`go build` / `go test ./...` green; `gofmt` clean (the touched block is now tab-indented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)