### PR TITLE
fix: make the "not in same network as caddy" warning actionable

### DIFF
--- a/generator/containers.go
+++ b/generator/containers.go
@@ -1,6 +1,9 @@
 package generator
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/docker/docker/api/types"
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/caddyfile"
 	"go.uber.org/zap"
@@ -22,7 +25,7 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container,
 	for networkName, network := range container.NetworkSettings.Networks {
 		include := false
 
-		if !onlyIngressIps  {
+		if !onlyIngressIps {
 			include = true
 		} else if overrideNetwork {
 			include = networkName == ingressNetworkFromLabel
@@ -36,9 +39,26 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *types.Container,
 	}
 
 	if len(ips) == 0 {
-		logger.Warn("Container is not in same network as caddy", zap.String("container", container.ID), zap.String("container id", container.ID))
-
+		networks := make([]string, 0, len(container.NetworkSettings.Networks))
+		for networkName := range container.NetworkSettings.Networks {
+			networks = append(networks, networkName)
+		}
+		sort.Strings(networks)
+		logger.Warn("Container is not in same network as caddy",
+			zap.String("container", containerName(container)),
+			zap.Strings("container networks", networks),
+			zap.Strings("ingress networks", g.options.IngressNetworks),
+		)
 	}
 
 	return ips, nil
+}
+
+// containerName returns a human-friendly container name (without Docker's
+// leading slash), falling back to the container ID.
+func containerName(container *types.Container) string {
+	if len(container.Names) > 0 {
+		return strings.TrimPrefix(container.Names[0], "/")
+	}
+	return container.ID
 }

--- a/generator/containers_test.go
+++ b/generator/containers_test.go
@@ -75,7 +75,8 @@ func TestContainers_DifferentNetwork(t *testing.T) {
 	dockerClient := createBasicDockerClientMock()
 	dockerClient.ContainersData = []types.Container{
 		{
-			ID: "CONTAINER-ID",
+			ID:    "CONTAINER-ID",
+			Names: []string{"/lonely-container"},
 			NetworkSettings: &types.SummaryNetworkSettings{
 				Networks: map[string]*network.EndpointSettings{
 					"other-network": {
@@ -96,7 +97,7 @@ func TestContainers_DifferentNetwork(t *testing.T) {
 		"}\n"
 
 	const expectedLogs = commonLogs +
-		`WARN	Container is not in same network as caddy	{"container": "CONTAINER-ID", "container id": "CONTAINER-ID"}` + newLine
+		`WARN	Container is not in same network as caddy	{"container": "lonely-container", "container networks": ["other-network"], "ingress networks": []}` + newLine
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }


### PR DESCRIPTION
Refs #759.

## Problem

The container warning logged the container ID **twice** and nothing else:

```go
logger.Warn("Container is not in same network as caddy",
    zap.String("container", container.ID),
    zap.String("container id", container.ID))
```

→ `WARN Container is not in same network as caddy {"container": "abc123", "container id": "abc123"}`

In #759 the user sees this flooding the logs while routing still works, with no way to tell **which** container or **why** (no name, no networks).

## Change

Log the container **name**, the networks it's **actually attached to**, and the **configured ingress networks**:

```
WARN Container is not in same network as caddy
  {"container": "lonely-container", "container networks": ["other-network"], "ingress networks": ["caddy_default"]}
```

Now the mismatch is obvious at a glance (e.g. a container only on `other-network` while ingress is `caddy_default` — common when compose `include:` prefixes network names per sub-project).

Also fixes a couple of pre-existing `gofmt` nits in the touched block.

## Notes

- Only the container path is changed (the subject of #759). The service warnings already log the service name.
- This doesn't silence the warning — it makes it diagnosable. Combined with #806 (`--log-level` / `CADDY_DOCKER_LOG_LEVEL`), users can also quiet it if intended.

## Tests

`TestContainers_DifferentNetwork` updated to assert the new fields (container name via `Names`, attached networks, ingress networks). `go build` / `vet` / `test ./...` green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)