### PR TITLE
Update Alpine base image to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} alpine:3.20.3 as alpine
+FROM --platform=${BUILDPLATFORM} alpine:latest as alpine
 RUN apk add -U --no-cache ca-certificates
 
 # Image starts here

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3 as alpine
+FROM alpine:latest as alpine
 ARG TARGETPLATFORM
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 


### PR DESCRIPTION
Updates both Dockerfiles from Alpine 3.20.3 to `latest`.

What `trivy` says about the latest alpine image from Docker Hub:

```
$ IMAGE=lucaslorentz/caddy-docker-proxy:2.12.1-alpine
$ trivy image \
    --scanners vuln \
    --severity HIGH,CRITICAL \
    --format json \
    "$IMAGE" \
  | jq -r '
    .Results[]? as $result
    | $result.Vulnerabilities[]?
    | [
        .Severity,
        .VulnerabilityID,
        .PkgName,
        .InstalledVersion,
        (.FixedVersion // ""),
        $result.Target
      ]
    | @tsv
  '
2026-06-18T09:55:56-07:00       INFO    [vuln] Vulnerability scanning is enabled
2026-06-18T09:55:56-07:00       INFO    Detected OS     family="alpine" version="3.20.3"
2026-06-18T09:55:56-07:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.20" repository="3.20" pkg_num=24
2026-06-18T09:55:56-07:00       INFO    Number of language-specific files       num=1
2026-06-18T09:55:56-07:00       INFO    [gobinary] Detecting vulnerabilities...
2026-06-18T09:55:57-07:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/docs/v0.71/guide/scanner/vulnerability#severity-selection for details.
2026-06-18T09:55:57-07:00       WARN    This OS version is no longer supported by the distribution      family="alpine" version="3.20.3"
2026-06-18T09:55:57-07:00       WARN    The vulnerability detection may be insufficient because security updates are not provided
CRITICAL        CVE-2026-31789  libcrypto3      3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2024-12797  libcrypto3      3.3.2-r0        3.3.3-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2025-15467  libcrypto3      3.3.2-r0        3.3.6-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2025-69421  libcrypto3      3.3.2-r0        3.3.6-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28387  libcrypto3      3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28388  libcrypto3      3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28389  libcrypto3      3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28390  libcrypto3      3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
CRITICAL        CVE-2026-31789  libssl3 3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2024-12797  libssl3 3.3.2-r0        3.3.3-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2025-15467  libssl3 3.3.2-r0        3.3.6-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2025-69421  libssl3 3.3.2-r0        3.3.6-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28387  libssl3 3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28388  libssl3 3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28389  libssl3 3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-28390  libssl3 3.3.2-r0        3.3.7-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2025-26519  musl    1.2.5-r0        1.2.5-r1        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-40200  musl    1.2.5-r0        1.2.5-r3        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2025-26519  musl-utils      1.2.5-r0        1.2.5-r1        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-40200  musl-utils      1.2.5-r0        1.2.5-r3        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-22184  zlib    1.3.1-r1        1.3.2-r0        lucaslorentz/caddy-docker-proxy:2.12.1-alpine (alpine 3.20.3)
HIGH    CVE-2026-52844  github.com/caddyserver/caddy/v2 v2.11.3 2.11.4  bin/caddy
HIGH    CVE-2026-52845  github.com/caddyserver/caddy/v2 v2.11.3 2.11.4  bin/caddy
HIGH    CVE-2026-34040  github.com/docker/docker        v28.5.2+incompatible    29.3.1  bin/caddy
HIGH    CVE-2026-41567  github.com/docker/docker        v28.5.2+incompatible            bin/caddy
HIGH    CVE-2026-42306  github.com/docker/docker        v28.5.2+incompatible            bin/caddy
HIGH    CVE-2026-34986  github.com/go-jose/go-jose/v3   v3.0.4  3.0.5   bin/caddy
CRITICAL        CVE-2025-68121  stdlib  v1.25.0 1.24.13, 1.25.7, 1.26.0-rc.3    bin/caddy
HIGH    CVE-2025-61726  stdlib  v1.25.0 1.24.12, 1.25.6 bin/caddy
HIGH    CVE-2025-61729  stdlib  v1.25.0 1.24.11, 1.25.5 bin/caddy
HIGH    CVE-2026-25679  stdlib  v1.25.0 1.25.8, 1.26.1  bin/caddy
HIGH    CVE-2026-32280  stdlib  v1.25.0 1.25.9, 1.26.2  bin/caddy
HIGH    CVE-2026-32281  stdlib  v1.25.0 1.25.9, 1.26.2  bin/caddy
HIGH    CVE-2026-32283  stdlib  v1.25.0 1.25.9, 1.26.2  bin/caddy
HIGH    CVE-2026-33811  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-33814  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-39820  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-39823  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-39825  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-39836  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-42499  stdlib  v1.25.0 1.25.10, 1.26.3 bin/caddy
HIGH    CVE-2026-42504  stdlib  v1.25.0 1.25.11, 1.26.4 bin/caddy
$ trivy image --scanners vuln --format json "$IMAGE" \
  | jq -r '
    [.Results[]?.Vulnerabilities[]?]
    | group_by(.Severity)
    | .[]
    | "\(.[0].Severity)\t\(length)"
  '
2026-06-18T09:57:15-07:00       INFO    [vuln] Vulnerability scanning is enabled
2026-06-18T09:57:15-07:00       INFO    Detected OS     family="alpine" version="3.20.3"
2026-06-18T09:57:15-07:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.20" repository="3.20" pkg_num=24
2026-06-18T09:57:15-07:00       INFO    Number of language-specific files       num=1
2026-06-18T09:57:15-07:00       INFO    [gobinary] Detecting vulnerabilities...
2026-06-18T09:57:15-07:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/docs/v0.71/guide/scanner/vulnerability#severity-selection for details.
2026-06-18T09:57:15-07:00       WARN    This OS version is no longer supported by the distribution      family="alpine" version="3.20.3"
2026-06-18T09:57:15-07:00       WARN    The vulnerability detection may be insufficient because security updates are not provided
CRITICAL        3
HIGH    39
LOW     25
MEDIUM  3
```

And with the latest alpine base image at 3.24:

```
$ IMAGE=local/caddy-docker-proxy:main-alpine-latest
$ trivy image \
    --scanners vuln \
    --severity HIGH,CRITICAL \
    --format json \
    "$IMAGE" \
  | jq -r '
    .Results[]? as $result
    | $result.Vulnerabilities[]?
    | [
        .Severity,
        .VulnerabilityID,
        .PkgName,
        .InstalledVersion,
        (.FixedVersion // ""),
        $result.Target
      ]
    | @tsv
  '
2026-06-18T10:01:38-07:00       INFO    [vuln] Vulnerability scanning is enabled
2026-06-18T10:01:38-07:00       INFO    Detected OS     family="alpine" version="3.24.1"
2026-06-18T10:01:38-07:00       WARN    This OS version is not on the EOL list  family="alpine" version="3.24"
2026-06-18T10:01:38-07:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.24" repository="3.24" pkg_num=26
2026-06-18T10:01:38-07:00       INFO    Number of language-specific files       num=1
2026-06-18T10:01:38-07:00       INFO    [gobinary] Detecting vulnerabilities...
HIGH    CVE-2026-34040  github.com/docker/docker        v28.5.2+incompatible    29.3.1  bin/caddy
HIGH    CVE-2026-41567  github.com/docker/docker        v28.5.2+incompatible            bin/caddy
HIGH    CVE-2026-42306  github.com/docker/docker        v28.5.2+incompatible            bin/caddy
$ trivy image --scanners vuln --format json "$IMAGE" \
  | jq -r '
    [.Results[]?.Vulnerabilities[]?]
    | group_by(.Severity)
    | .[]
    | "\(.[0].Severity)\t\(length)"
  '
2026-06-18T10:00:59-07:00       INFO    [vuln] Vulnerability scanning is enabled
2026-06-18T10:00:59-07:00       INFO    Detected OS     family="alpine" version="3.24.1"
2026-06-18T10:00:59-07:00       WARN    This OS version is not on the EOL list  family="alpine" version="3.24"
2026-06-18T10:00:59-07:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.24" repository="3.24" pkg_num=26
2026-06-18T10:00:59-07:00       INFO    Number of language-specific files       num=1
2026-06-18T10:00:59-07:00       INFO    [gobinary] Detecting vulnerabilities...
HIGH    3
MEDIUM  2
```

Tried to copy paste my terminal output but it might be a bit off... anyway let me know what you think? Seems really innocuous version bump. This pretty much lines up with the `FROM scratch` image on vulnerabilities (for either 3.20.* and 3.24.*).

Or instead of `alpine:3.24`, could just track `alpine:latest` and (I think) not have to worry about the alpine docker images, since this image is mainly for debugging. 

---

**Edit**: updated to track `latest`