### PR TITLE
ci: pin Alpine base image and track it via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} alpine:latest as alpine
+FROM --platform=${BUILDPLATFORM} alpine:3.24.1 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 # Image starts here

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:latest as alpine
+FROM alpine:3.24.1 as alpine
 ARG TARGETPLATFORM
 LABEL maintainer "Lucas Lorentz <lucaslorentzlara@hotmail.com>"
 


### PR DESCRIPTION
Follow-up to #813, which migrated the Docker client to Moby and bumped the Alpine base image — but pinned it to `alpine:latest`.

## Why

- **`alpine:latest` breaks reproducible builds** and is a supply-chain risk: the same Dockerfile produces different images over time, and there's no record of which Alpine version shipped.
- The base image had gone stale (sat at `3.20.3` for a long time) because **Dependabot only tracked `gomod`** — there was no `docker` ecosystem entry, so nothing ever proposed a bump.

## Changes

- Pin `Dockerfile` and `Dockerfile-alpine` to `alpine:3.24.1` (current latest patch).
- Add the `docker` package-ecosystem to `.github/dependabot.yml` so the base image is kept current via PRs, the same way Go modules are.

This keeps builds reproducible while still getting timely Alpine security bumps — automatically, instead of having to remember to float `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)