### PR TITLE
Build with Go 1.26

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.26
 
       - name: Checkout Code
         uses: actions/checkout@v5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lucaslorentz/caddy-docker-proxy/v2
 
-go 1.25.1
+go 1.26
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Title. Clears a few more vulnerabilities.

This could probably be tracked by dependabot as well.