### PR TITLE
Fix admin reloads over Unix sockets (#1)

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -310,7 +313,14 @@ func (dockerLoader *DockerLoader) updateServer(wg *sync.WaitGroup, server string
 	log := logger()
 	log.Info("Sending configuration to", zap.String("server", server))
 
-	url := "http://" + server + ":2019/load"
+	client, url, cleanup, err := dockerLoader.adminAPIEndpoint(server)
+	if err != nil {
+		log.Error("Failed to determine admin API endpoint for", zap.String("server", server), zap.Error(err))
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
 
 	postBody, err := dockerLoader.prepareServerConfig(server)
 	if err != nil {
@@ -324,12 +334,13 @@ func (dockerLoader *DockerLoader) updateServer(wg *sync.WaitGroup, server string
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 
 	if err != nil {
 		log.Error("Failed to send configuration to", zap.String("server", server), zap.Error(err))
 		return
 	}
+	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -345,6 +356,48 @@ func (dockerLoader *DockerLoader) updateServer(wg *sync.WaitGroup, server string
 	dockerLoader.serversVersions.Set(server, version)
 
 	log.Info("Successfully configured", zap.String("server", server))
+}
+
+func (dockerLoader *DockerLoader) adminAPIEndpoint(server string) (*http.Client, string, func(), error) {
+	adminListen := dockerLoader.options.AdminListen
+	if adminListen == "" {
+		return http.DefaultClient, "http://" + server + ":2019/load", nil, nil
+	}
+
+	adminAddr, err := caddy.ParseNetworkAddress(adminListen)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("invalid admin listen address %s: %w", adminListen, err)
+	}
+	if adminAddr.PortRangeSize() > 1 {
+		return nil, "", nil, fmt.Errorf("admin listen address %s must resolve to a single endpoint", adminListen)
+	}
+
+	if adminAddr.IsUnixNetwork() {
+		socketPath, _, _ := strings.Cut(adminAddr.Host, "|")
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, adminAddr.Network, socketPath)
+		}
+		// Caddy skips Host enforcement for Unix/fd admin listeners; this host
+		// only gives net/http a valid URL for the request.
+		return &http.Client{Transport: transport}, "http://127.0.0.1/load", transport.CloseIdleConnections, nil
+	}
+
+	host := adminAddr.Host
+	if isWildcardHost(host) {
+		host = server
+	}
+	port := strconv.FormatUint(uint64(adminAddr.StartPort), 10)
+	return http.DefaultClient, "http://" + net.JoinHostPort(host, port) + "/load", nil, nil
+}
+
+func isWildcardHost(host string) bool {
+	if host == "" {
+		return true
+	}
+	addr := net.ParseIP(host)
+	return addr != nil && addr.IsUnspecified()
 }
 
 // prepareServerConfig builds the config to push to server from the loader's last

--- a/loader_test.go
+++ b/loader_test.go
@@ -2,6 +2,9 @@ package caddydockerproxy
 
 import (
 	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
@@ -13,6 +16,97 @@ import (
 func TestGetServerAdminListen(t *testing.T) {
 	assert.Equal(t, "tcp/10.0.0.2:2019", getServerAdminListen(&config.Options{}, "10.0.0.2"))
 	assert.Equal(t, "tcp/0.0.0.0:2019", getServerAdminListen(&config.Options{AdminListen: "tcp/0.0.0.0:2019"}, "10.0.0.2"))
+}
+
+func TestAdminAPIEndpoint(t *testing.T) {
+	t.Run("uses default TCP admin endpoint", func(t *testing.T) {
+		loader := &DockerLoader{options: &config.Options{}}
+
+		client, url, cleanup, err := loader.adminAPIEndpoint("10.0.0.2")
+
+		require.NoError(t, err)
+		assert.Same(t, http.DefaultClient, client)
+		assert.Equal(t, "http://10.0.0.2:2019/load", url)
+		assert.Nil(t, cleanup)
+	})
+
+	t.Run("uses explicit TCP port with controlled server for wildcard host", func(t *testing.T) {
+		loader := &DockerLoader{options: &config.Options{AdminListen: "tcp/0.0.0.0:8080"}}
+
+		client, url, cleanup, err := loader.adminAPIEndpoint("10.0.0.2")
+
+		require.NoError(t, err)
+		assert.Same(t, http.DefaultClient, client)
+		assert.Equal(t, "http://10.0.0.2:8080/load", url)
+		assert.Nil(t, cleanup)
+	})
+
+	t.Run("uses explicit TCP host and port", func(t *testing.T) {
+		loader := &DockerLoader{options: &config.Options{AdminListen: "tcp/127.0.0.1:8080"}}
+
+		client, url, cleanup, err := loader.adminAPIEndpoint("10.0.0.2")
+
+		require.NoError(t, err)
+		assert.Same(t, http.DefaultClient, client)
+		assert.Equal(t, "http://127.0.0.1:8080/load", url)
+		assert.Nil(t, cleanup)
+	})
+
+	t.Run("uses Unix socket admin endpoint", func(t *testing.T) {
+		socketPath := t.TempDir() + "/caddy-admin.sock"
+		listener, err := net.Listen("unix", socketPath)
+		require.NoError(t, err)
+
+		requests := make(chan *http.Request, 1)
+		server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests <- r
+			w.WriteHeader(http.StatusOK)
+		})}
+		done := make(chan error, 1)
+		go func() {
+			done <- server.Serve(listener)
+		}()
+		t.Cleanup(func() {
+			require.NoError(t, server.Close())
+			err := <-done
+			if err != nil && err != http.ErrServerClosed {
+				t.Errorf("server failed: %v", err)
+			}
+		})
+
+		loader := &DockerLoader{options: &config.Options{AdminListen: "unix/" + socketPath + "|0200"}}
+
+		client, url, cleanup, err := loader.adminAPIEndpoint("localhost")
+		require.NoError(t, err)
+		require.NotNil(t, cleanup)
+		defer cleanup()
+		assert.Equal(t, "http://127.0.0.1/load", url)
+
+		resp, err := client.Post(url, "application/json", strings.NewReader(`{}`))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "/load", (<-requests).URL.Path)
+	})
+
+	t.Run("rejects invalid admin listen", func(t *testing.T) {
+		loader := &DockerLoader{options: &config.Options{AdminListen: "tcp/localhost:not-a-port"}}
+
+		_, _, _, err := loader.adminAPIEndpoint("localhost")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid admin listen address")
+	})
+
+	t.Run("rejects admin listen port ranges", func(t *testing.T) {
+		loader := &DockerLoader{options: &config.Options{AdminListen: "tcp/localhost:2019-2020"}}
+
+		_, _, _, err := loader.adminAPIEndpoint("localhost")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must resolve to a single endpoint")
+	})
 }
 
 func unmarshalConfig(t *testing.T, data []byte) *caddy.Config {


### PR DESCRIPTION
Related to lucaslorentz/caddy-docker-proxy#804

## Summary

Fixes admin reloads when `CADDY_ADMIN` is configured to use a Caddy Unix socket address, such as `unix//run/caddy-admin.sock`.

The loader now builds the admin API request target from the configured admin listen address when one is provided. Unix socket admin endpoints use a custom HTTP transport that dials the socket directly, while the request URL uses `127.0.0.1` only to satisfy `net/http` URL requirements. TCP behavior remains unchanged for the default path and now honors explicit TCP admin ports.

## Points of interest

- `loader.go:316-343`: `updateServer` now uses the resolved admin API endpoint, closes response bodies, and runs endpoint cleanup when needed.
- `loader.go:361-392`: `adminAPIEndpoint` handles default TCP, explicit TCP, wildcard TCP bind hosts, and Unix socket admin listeners.
- `loader_test.go:21-109`: Adds coverage for default TCP, explicit TCP ports, Unix socket requests, invalid listen addresses, and port range rejection.

## Decisions Made

### D1 Preserve the default TCP reload path

When `AdminListen` is unset, the loader still returns `http://<server>:2019/load` directly instead of parsing the synthesized Caddy listen address.

**Alternatives considered**

- D1A: Always parse `tcp/<server>:2019`. Not selected because it could turn previously tolerated server values into parse failures.

**Assumptions used**

- The default path should remain behaviorally compatible with the pre-existing implementation.

### D2 Honor explicit TCP admin ports while replacing wildcard hosts

When `AdminListen` is an explicit TCP address, the reload URL now uses the configured port. If the configured host is a wildcard bind address, such as `0.0.0.0`, the loader dials the controlled server address instead.

**Alternatives considered**

- D2A: Dial the parsed TCP host directly. Not selected because dialing `0.0.0.0` is the wrong behavior for controlled remote servers.
- D2B: Keep TCP hard-coded to `:2019`. Not selected because explicit TCP admin ports should work consistently with explicit Unix socket admin addresses.

**Assumptions used**

- Wildcard listen hosts describe where Caddy binds, not the routable address the loader should dial.