### PR TITLE
Load config in-process for local push instead of admin HTTP

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -310,41 +310,70 @@ func (dockerLoader *DockerLoader) updateServer(wg *sync.WaitGroup, server string
 	log := logger()
 	log.Info("Sending configuration to", zap.String("server", server))
 
-	url := "http://" + server + ":2019/load"
-
 	postBody, err := dockerLoader.prepareServerConfig(server)
 	if err != nil {
 		log.Error("Failed to prepare configuration for", zap.String("server", server), zap.Error(err))
 		return
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(postBody))
-	if err != nil {
-		log.Error("Failed to create request to", zap.String("server", server), zap.Error(err))
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	if server == "localhost" {
+		// The loader runs in the same process as the local Caddy (controller and
+		// server share an instance), so load the config directly instead of
+		// looping back through the admin API over HTTP. This drops the dependency
+		// on the local admin endpoint being reachable - or even enabled.
+		//
+		// forceReload is false so an unchanged config is a no-op, matching the
+		// admin /load default. The recover guards parity with the HTTP path: the
+		// admin endpoint's net/http handler recovers panics during provisioning,
+		// but a direct call would otherwise crash the whole process.
+		if err := loadLocalConfig(postBody); err != nil {
+			log.Error("Failed to load configuration locally", zap.String("server", server), zap.Error(err))
+			return
+		}
+	} else {
+		url := "http://" + server + ":2019/load"
 
-	if err != nil {
-		log.Error("Failed to send configuration to", zap.String("server", server), zap.Error(err))
-		return
-	}
+		req, err := http.NewRequest("POST", url, bytes.NewBuffer(postBody))
+		if err != nil {
+			log.Error("Failed to create request to", zap.String("server", server), zap.Error(err))
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
 
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error("Failed to read response from", zap.String("server", server), zap.Error(err))
-		return
-	}
+		if err != nil {
+			log.Error("Failed to send configuration to", zap.String("server", server), zap.Error(err))
+			return
+		}
+		defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		log.Error("Error response from server", zap.String("server", server), zap.Int("status code", resp.StatusCode), zap.ByteString("body", bodyBytes))
-		return
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Error("Failed to read response from", zap.String("server", server), zap.Error(err))
+			return
+		}
+
+		if resp.StatusCode != 200 {
+			log.Error("Error response from server", zap.String("server", server), zap.Int("status code", resp.StatusCode), zap.ByteString("body", bodyBytes))
+			return
+		}
 	}
 
 	dockerLoader.serversVersions.Set(server, version)
 
 	log.Info("Successfully configured", zap.String("server", server))
+}
+
+// loadLocalConfig applies the config to the in-process Caddy via caddy.Load,
+// recovering any panic from config provisioning into an error so a poison
+// config fails the reload instead of crashing the process.
+func loadLocalConfig(postBody []byte) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic loading config locally: %v", r)
+		}
+	}()
+	return caddy.Load(postBody, false)
 }
 
 // prepareServerConfig builds the config to push to server from the loader's last

--- a/local_load_integration_test.go
+++ b/local_load_integration_test.go
@@ -1,0 +1,89 @@
+package caddydockerproxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/config"
+	"github.com/lucaslorentz/caddy-docker-proxy/v2/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadLocalConfig must surface a bad config as an error (and must not panic),
+// so a poison config fails the reload instead of crashing the process.
+func TestLoadLocalConfig_ReturnsErrorOnInvalidConfig(t *testing.T) {
+	err := loadLocalConfig([]byte("this is not valid json"))
+	require.Error(t, err)
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// Verifies that updateServer("localhost") applies the generated config straight
+// into the running Caddy via caddy.Load, with no admin API involved. The
+// instance is booted with the admin API disabled, so if the loader fell back to
+// the HTTP push it would POST to localhost:2019 and fail - the only way the
+// served config can go live here is the in-process load path.
+func TestIntegration_LocalPushUsesCaddyLoad(t *testing.T) {
+	appPort := freePort(t)
+	adminPort := freePort(t)
+
+	caddyfile := fmt.Sprintf(":%d {\n\trespond \"docker-proxy-local-load\"\n}\n", appPort)
+	configJSON, warn, err := caddyconfig.GetAdapter("caddyfile").Adapt([]byte(caddyfile), nil)
+	require.NoError(t, err)
+	require.Nil(t, warn)
+
+	require.NoError(t, caddy.Run(&caddy.Config{Admin: &caddy.AdminConfig{Disabled: true}}))
+	t.Cleanup(func() { _ = caddy.Stop() })
+
+	loader := &DockerLoader{
+		options:         &config.Options{AdminListen: fmt.Sprintf("tcp/localhost:%d", adminPort)},
+		lastJSONConfig:  configJSON,
+		lastVersion:     1,
+		serversVersions: utils.NewStringInt64CMap(),
+		serversUpdating: utils.NewStringBoolCMap(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	loader.updateServer(&wg, "localhost")
+	wg.Wait()
+
+	// The version is only recorded on a successful load.
+	require.Equal(t, int64(1), loader.serversVersions.Get("localhost"))
+
+	// Prove the config is live in-process by hitting the served port.
+	url := fmt.Sprintf("http://127.0.0.1:%d/", appPort)
+	var body string
+	var status int
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(url)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		body = string(b)
+		status = resp.StatusCode
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
+
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "docker-proxy-local-load", body)
+}


### PR DESCRIPTION
## Summary

For `server == "localhost"` the loader now applies config **in-process via `caddy.Load`** instead of POSTing to its own admin API at a hardcoded `http://localhost:2019/load`. Remote controlled servers keep the HTTP admin push.

The self-push runs in the same process as the local Caddy, yet looped through HTTP — and the hardcoded `:2019` broke whenever `CADDY_ADMIN` moved admin elsewhere (custom port / unix socket): the first reload relocated admin, then every later push to `:2019` failed. Loading in-process drops that dependency; the configured admin listen is still applied because it's part of the loaded config. (The loader used `caddy.Load` directly until controller/server were split in `198aa8c`; this restores it for the local case only.)

## Key points

- `loadLocalConfig` wraps `caddy.Load` in a `recover` — the admin endpoint's `net/http` handler recovers provisioning panics, so a poison config must fail the reload here instead of crashing the process.
- `forceReload: false`, matching the admin `/load` default (unchanged config = no-op).
- Remote push now also closes the response body.

## Testing

- `TestIntegration_LocalPushUsesCaddyLoad` — boots Caddy with the admin API **disabled**, calls `updateServer("localhost")`, and confirms the served port responds; only the in-process path can make that pass (an HTTP fallback would hit a dead `:2019`).
- Error-path unit test (bad config → error, no panic); `go test ./...` green.
- Docker swarm run from this branch: standalone routes return 200, and repeated forced Caddyfile updates (label rename, header add, label removal, caddy-service restart) each reload via `caddy.Load` with no push errors; with `forceReload: false`, no-op reloads are deduped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)