### PR TITLE
fix: ensure local load keeps admin disabled

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -349,9 +349,14 @@ func (dockerLoader *DockerLoader) prepareServerConfig(server string) ([]byte, er
 		return nil, err
 	}
 
-	// Respect an explicit admin endpoint, but override "admin off" since the
-	// plugin requires the admin API.
-	if config.Admin == nil || config.Admin.Disabled {
+	// Local loads happen in-process, so keep the admin API disabled unless the
+	// config explicitly enables it. Remote servers still need an admin endpoint
+	// for controller pushes.
+	if server == "localhost" {
+		if config.Admin == nil || config.Admin.Disabled {
+			config.Admin = &caddy.AdminConfig{Disabled: true}
+		}
+	} else if config.Admin == nil || config.Admin.Disabled {
 		config.Admin = &caddy.AdminConfig{Listen: getServerAdminListen(dockerLoader.options, server)}
 	}
 

--- a/loader.go
+++ b/loader.go
@@ -352,12 +352,12 @@ func (dockerLoader *DockerLoader) prepareServerConfig(server string) ([]byte, er
 	// Local loads happen in-process, so keep the admin API disabled unless the
 	// config explicitly enables it. Remote servers still need an admin endpoint
 	// for controller pushes.
-	if server == "localhost" {
-		if config.Admin == nil || config.Admin.Disabled {
+	if config.Admin == nil || config.Admin.Disabled {
+		if server == localServer {
 			config.Admin = &caddy.AdminConfig{Disabled: true}
+		} else {
+			config.Admin = &caddy.AdminConfig{Listen: getServerAdminListen(dockerLoader.options, server)}
 		}
-	} else if config.Admin == nil || config.Admin.Disabled {
-		config.Admin = &caddy.AdminConfig{Listen: getServerAdminListen(dockerLoader.options, server)}
 	}
 
 	// Re-apply our logging only to the local Caddy (the standalone self-push),

--- a/loader_test.go
+++ b/loader_test.go
@@ -46,14 +46,32 @@ func TestPrepareServerConfig(t *testing.T) {
 		assert.Equal(t, "tcp/0.0.0.0:2019", unmarshalConfig(t, out).Admin.Listen)
 	})
 
-	t.Run("overrides admin off", func(t *testing.T) {
+	t.Run("overrides admin off for remote servers", func(t *testing.T) {
+		in, err := json.Marshal(&caddy.Config{Admin: &caddy.AdminConfig{Disabled: true}})
+		require.NoError(t, err)
+		out, err := newLoader(in, nil).prepareServerConfig("10.0.0.2")
+		require.NoError(t, err)
+		result := unmarshalConfig(t, out)
+		assert.False(t, result.Admin.Disabled)
+		assert.Equal(t, "tcp/10.0.0.2:2019", result.Admin.Listen)
+	})
+
+	t.Run("keeps admin off for local server", func(t *testing.T) {
 		in, err := json.Marshal(&caddy.Config{Admin: &caddy.AdminConfig{Disabled: true}})
 		require.NoError(t, err)
 		out, err := newLoader(in, nil).prepareServerConfig("localhost")
 		require.NoError(t, err)
 		result := unmarshalConfig(t, out)
-		assert.False(t, result.Admin.Disabled)
-		assert.Equal(t, "tcp/localhost:2019", result.Admin.Listen)
+		assert.True(t, result.Admin.Disabled)
+		assert.Empty(t, result.Admin.Listen)
+	})
+
+	t.Run("disables admin fallback for local server", func(t *testing.T) {
+		out, err := newLoader(empty, nil).prepareServerConfig("localhost")
+		require.NoError(t, err)
+		result := unmarshalConfig(t, out)
+		assert.True(t, result.Admin.Disabled)
+		assert.Empty(t, result.Admin.Listen)
 	})
 
 	t.Run("injects logging on the local Caddy", func(t *testing.T) {

--- a/local_load_integration_test.go
+++ b/local_load_integration_test.go
@@ -86,4 +86,24 @@ func TestIntegration_LocalPushUsesCaddyLoad(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, status)
 	assert.Equal(t, "docker-proxy-local-load", body)
+
+	// Prove the local load did not reopen the admin endpoint. The localhost
+	// update path should not need an admin API because it loads config
+	// in-process.
+	adminURL := fmt.Sprintf("http://127.0.0.1:%d/config/", adminPort)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	client := &http.Client{
+		Timeout:   100 * time.Millisecond,
+		Transport: transport,
+	}
+	defer transport.CloseIdleConnections()
+
+	assert.Never(t, func() bool {
+		resp, err := client.Get(adminURL)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return true
+	}, time.Second, 50*time.Millisecond, "local load must keep the admin endpoint disabled")
 }


### PR DESCRIPTION
## Summary

This builds on the local in-process reload path by ensuring it does not accidentally reopen Caddy’s admin endpoint.

For localhost reloads, `caddy-docker-proxy` no longer needs to POST to Caddy’s admin API because the config is applied directly with `caddy.Load`. The remote-server reload path still needs an admin endpoint, but the local path does not.

## Bug

Before this change, `prepareServerConfig("localhost")` still applied the same fallback behavior used for remote controlled servers:

- if the generated config had no `admin` block, it injected `admin.listen`
- if the generated config had `admin off`, it replaced that with `admin.listen`
- if `AdminListen` was configured, it used that value
- otherwise it fell back to `tcp/localhost:2019`

That made sense when localhost reloads also depended on the admin API. After switching localhost reloads to `caddy.Load`, this fallback undermines the reason to use the `caddy.Load` API instead of the admin API.

The practical effect was that a process started with admin disabled could have admin silently re-enabled on the first local config load. In standalone/local mode, the loader would prepare a config with an injected admin listener, then `caddy.Load` would apply that config and Caddy would start the admin endpoint.

## Fix

The local and remote paths now diverge:

- `localhost` loads config in-process and keeps admin disabled when the generated config had admin disabled or omitted
- remote controlled servers still receive the admin listener fallback because the controller still pushes config to them through the admin API
- explicit admin configuration is still respected

## Test Coverage

The existing local-load integration test now also verifies that the configured admin address does not become reachable after `updateServer("localhost")`.

The first test commit demonstrates the failure against the current implementation: Caddy starts the admin endpoint and responds to `/config/`.

The fix commit makes the same test pass by keeping admin disabled for local in-process loads.
