### PR TITLE
fix: skip container IP addresses for non-running containers

### DIFF
--- a/docker/client_mock.go
+++ b/docker/client_mock.go
@@ -3,7 +3,7 @@ package docker
 import (
 	"context"
 
-	"github.com/moby/moby/api/types/container"
+	mobyContainer "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/swarm"
@@ -13,22 +13,32 @@ import (
 
 // ClientMock allows easily mocking of docker client data
 type ClientMock struct {
-	ContainersData       []container.Summary
+	ContainersData       []mobyContainer.Summary
 	ServicesData         []swarm.Service
 	ConfigsData          []swarm.Config
 	TasksData            []swarm.Task
 	TaskListErr          error
 	NetworksData         []network.Summary
 	InfoData             system.Info
-	ContainerInspectData map[string]container.InspectResponse
+	ContainerInspectData map[string]mobyContainer.InspectResponse
 	NetworkInspectData   map[string]network.Inspect
 	EventsChannel        chan events.Message
 	ErrorsChannel        chan error
 }
 
 // ContainerList list all containers
-func (mock *ClientMock) ContainerList(ctx context.Context, options client.ContainerListOptions) ([]container.Summary, error) {
-	return mock.ContainersData, nil
+func (mock *ClientMock) ContainerList(ctx context.Context, options client.ContainerListOptions) ([]mobyContainer.Summary, error) {
+	var containers []mobyContainer.Summary
+	for _, container := range mock.ContainersData {
+		if container.State == "" {
+			container.State = mobyContainer.StateRunning
+		}
+		if !options.All && container.State != mobyContainer.StateRunning {
+			continue
+		}
+		containers = append(containers, container)
+	}
+	return containers, nil
 }
 
 // ServiceList list all services
@@ -70,7 +80,7 @@ func (mock *ClientMock) Info(ctx context.Context) (system.Info, error) {
 }
 
 // ContainerInspect returns information about a specific container
-func (mock *ClientMock) ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error) {
+func (mock *ClientMock) ContainerInspect(ctx context.Context, containerID string) (mobyContainer.InspectResponse, error) {
 	return mock.ContainerInspectData[containerID], nil
 }
 

--- a/generator/containers.go
+++ b/generator/containers.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 
 	"github.com/lucaslorentz/caddy-docker-proxy/v2/caddyfile"
-	"github.com/moby/moby/api/types/container"
+	mobyContainer "github.com/moby/moby/api/types/container"
 	"go.uber.org/zap"
 )
 
-func (g *CaddyfileGenerator) getContainerCaddyfile(container *container.Summary, logger *zap.Logger) (*caddyfile.Container, error) {
+func (g *CaddyfileGenerator) getContainerCaddyfile(container *mobyContainer.Summary, logger *zap.Logger) (*caddyfile.Container, error) {
 	caddyLabels := g.filterLabels(container.Labels)
 
 	return labelsToCaddyfile(caddyLabels, container, func() ([]string, error) {
@@ -17,8 +17,12 @@ func (g *CaddyfileGenerator) getContainerCaddyfile(container *container.Summary,
 	})
 }
 
-func (g *CaddyfileGenerator) getContainerIPAddresses(container *container.Summary, logger *zap.Logger, onlyIngressIps bool) ([]string, error) {
+func (g *CaddyfileGenerator) getContainerIPAddresses(container *mobyContainer.Summary, logger *zap.Logger, onlyIngressIps bool) ([]string, error) {
 	ips := []string{}
+
+	if container.State != mobyContainer.StateRunning {
+		return ips, nil
+	}
 
 	ingressNetworkFromLabel, overrideNetwork := container.Labels[IngressNetworkLabel]
 
@@ -56,7 +60,7 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *container.Summar
 
 // containerName returns a human-friendly container name (without Docker's
 // leading slash), falling back to the container ID.
-func containerName(container *container.Summary) string {
+func containerName(container *mobyContainer.Summary) string {
 	if len(container.Names) > 0 {
 		return strings.TrimPrefix(container.Names[0], "/")
 	}

--- a/generator/containers_test.go
+++ b/generator/containers_test.go
@@ -379,3 +379,98 @@ func TestContainers_WithSnippets(t *testing.T) {
 
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
+
+func TestContainers_ScanStoppedContainers_False(t *testing.T) {
+	dockerClient := createBasicDockerClientMock()
+	dockerClient.ContainersData = []container.Summary{
+		{
+			ID: "CONTAINER-ID",
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"caddy-network": {
+						IPAddress: netip.MustParseAddr("172.17.0.1"),
+						NetworkID: caddyNetworkID,
+					},
+				},
+			},
+			Labels: map[string]string{
+				fmtLabel("%s"):               "service.testdomain.com",
+				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
+			},
+			State: container.StateRunning,
+		},
+		{
+			ID: "CONTAINER-ID2",
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"caddy-network": {
+						NetworkID: caddyNetworkID,
+					},
+				},
+			},
+			Labels: map[string]string{
+				fmtLabel("%s"):               "service2.testdomain.com",
+				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
+			},
+			State: container.StateExited,
+		},
+	}
+
+	const expectedCaddyfile = "service.testdomain.com {\n" +
+		"	reverse_proxy 172.17.0.1\n" +
+		"}\n"
+
+	const expectedLogs = swarmIsAvailableLog
+
+	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
+}
+
+func TestContainers_ScanStoppedContainers_True(t *testing.T) {
+	dockerClient := createBasicDockerClientMock()
+	dockerClient.ContainersData = []container.Summary{
+		{
+			ID: "CONTAINER-ID",
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"caddy-network": {
+						IPAddress: netip.MustParseAddr("172.17.0.1"),
+						NetworkID: caddyNetworkID,
+					},
+				},
+			},
+			Labels: map[string]string{
+				fmtLabel("%s"):               "service.testdomain.com",
+				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
+			},
+			State: container.StateRunning,
+		},
+		{
+			ID: "CONTAINER-ID2",
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"caddy-network": {
+						NetworkID: caddyNetworkID,
+					},
+				},
+			},
+			Labels: map[string]string{
+				fmtLabel("%s"):               "service2.testdomain.com",
+				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
+			},
+			State: container.StateExited,
+		},
+	}
+
+	const expectedCaddyfile = "service.testdomain.com {\n" +
+		"	reverse_proxy 172.17.0.1\n" +
+		"}\n" +
+		"service2.testdomain.com {\n" +
+		"	reverse_proxy\n" +
+		"}\n"
+
+	const expectedLogs = swarmIsAvailableLog
+
+	testGeneration(t, dockerClient, func(options *config.Options) {
+		options.ScanStoppedContainers = true
+	}, expectedCaddyfile, expectedLogs)
+}


### PR DESCRIPTION
After the latest update (v2.13.0), new warnings started appearing in logs that were not present before:

```json
{"level":"warn","ts":1782899007.4949086,"logger":"docker-proxy","msg":"Container is not in same network as caddy","container":"firefox","container networks":["network1","network2"],"ingress networks":["network2"]}
```
and `CADDY_INGRESS_NETWORKS=network2`

The firefox container in this case is stopped.

I've set `CADDY_DOCKER_SCAN_STOPPED_CONTAINERS=true` in order to support Sablier, so stopped containers are intentionally included in the scan and can be started on demand.

With stopped containers included in the scan, the network check is executed on containers that have no active runtime networking state. This leads to false-positive warnings even though the setup is valid.

### Fix

Skip IP resolution and network validation when the container is not running.

### Tests

Added and updated some tests logic + manual testing with custom caddy image

### Reference

This probably happened due to #813, in particular https://github.com/lucaslorentz/caddy-docker-proxy/commit/21c56d57c119d833a9e9ec4f53496613376aba75#diff-6e8b88a8d296f10ad00b020c06d86a1f6647223c712c1a3e95f0701d1d759881R36