### PR TITLE
fix: don't warn "not in same network" for stopped containers without an IP

### DIFF
--- a/generator/containers.go
+++ b/generator/containers.go
@@ -19,6 +19,7 @@ func (g *CaddyfileGenerator) getContainerCaddyfile(container *container.Summary,
 
 func (g *CaddyfileGenerator) getContainerIPAddresses(container *container.Summary, logger *zap.Logger, onlyIngressIps bool) ([]string, error) {
 	ips := []string{}
+	inIngressNetwork := false
 
 	ingressNetworkFromLabel, overrideNetwork := container.Labels[IngressNetworkLabel]
 
@@ -30,15 +31,19 @@ func (g *CaddyfileGenerator) getContainerIPAddresses(container *container.Summar
 		} else if overrideNetwork {
 			include = networkName == ingressNetworkFromLabel
 		} else {
-			include = g.ingressNetworks[network.NetworkID]
+			include = g.ingressNetworks[network.NetworkID] || g.ingressNetworks[networkName]
 		}
 
-		if include && network.IPAddress.IsValid() {
-			ips = append(ips, network.IPAddress.String())
+		if include {
+			inIngressNetwork = true
+			if network.IPAddress.IsValid() {
+				ips = append(ips, network.IPAddress.String())
+			}
 		}
 	}
 
-	if len(ips) == 0 {
+	// Warns when the container shares no ingress network with caddy.
+	if !inIngressNetwork {
 		networks := make([]string, 0, len(container.NetworkSettings.Networks))
 		for networkName := range container.NetworkSettings.Networks {
 			networks = append(networks, networkName)

--- a/generator/containers_test.go
+++ b/generator/containers_test.go
@@ -103,6 +103,71 @@ func TestContainers_DifferentNetwork(t *testing.T) {
 	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
 }
 
+// A stopped container surfaced by CADDY_DOCKER_SCAN_STOPPED_CONTAINERS still
+// reports its ingress network but has released its runtime IP address. It is in
+// the same network as caddy, so it must not emit the "not in same network"
+// warning (matched here by network ID).
+func TestContainers_StoppedContainerInIngressNetworkDoesNotWarn(t *testing.T) {
+	dockerClient := createBasicDockerClientMock()
+	dockerClient.ContainersData = []container.Summary{
+		{
+			ID:    "CONTAINER-ID",
+			Names: []string{"/stopped-container"},
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"caddy-network": {
+						// No IPAddress: a stopped container has no runtime IP.
+						NetworkID: caddyNetworkID,
+					},
+				},
+			},
+			Labels: map[string]string{
+				fmtLabel("%s"):               "service.testdomain.com",
+				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
+			},
+		},
+	}
+
+	const expectedCaddyfile = "service.testdomain.com {\n" +
+		"	reverse_proxy\n" +
+		"}\n"
+
+	const expectedLogs = commonLogs
+
+	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
+}
+
+// Same as above, but the stopped container reports no runtime NetworkID, so the
+// ingress network is matched by name instead. Still no warning.
+func TestContainers_StoppedContainerMatchesIngressByName(t *testing.T) {
+	dockerClient := createBasicDockerClientMock()
+	dockerClient.ContainersData = []container.Summary{
+		{
+			ID:    "CONTAINER-ID",
+			Names: []string{"/stopped-container"},
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					// Keyed by the ingress network name, with neither a runtime
+					// NetworkID nor an IP address.
+					caddyNetworkName: {},
+				},
+			},
+			Labels: map[string]string{
+				fmtLabel("%s"):               "service.testdomain.com",
+				fmtLabel("%s.reverse_proxy"): "{{upstreams}}",
+			},
+		},
+	}
+
+	const expectedCaddyfile = "service.testdomain.com {\n" +
+		"	reverse_proxy\n" +
+		"}\n"
+
+	const expectedLogs = commonLogs
+
+	testGeneration(t, dockerClient, nil, expectedCaddyfile, expectedLogs)
+}
+
 func TestContainers_ManualIngressNetworks(t *testing.T) {
 	dockerClient := createBasicDockerClientMock()
 	dockerClient.NetworksData = []network.Summary{


### PR DESCRIPTION
## Problem

Since v2.13.0, a false-positive warning is logged for every stopped container when `CADDY_DOCKER_SCAN_STOPPED_CONTAINERS=true`:

```
WRN Container is not in same network as caddy
    container networks=["proxy-internal"] ingress networks=["proxy-internal"]
```

The container and ingress networks are identical — the container *is* in the right network. Fixes #820.

## Cause

`21c56d5` (Moby module migration) added an `IsValid()` guard when collecting IPs. Previously the empty IP of a stopped container was still appended (so `len(ips) > 0`); now nothing is appended, so `len(ips) == 0` and the "not in same network" warning fires — even though the container shares the ingress network. It just has no runtime IP because it is stopped.

## Fix

Warn based on whether the container shares an ingress network, not on whether an IP was collected. A container attached to an ingress network but without an IP (a stopped container) is in the right network and is no longer warned about; a genuine mismatch (no shared ingress network) still warns. The ingress network is also matched by name as a fallback, in case a stopped container reports the attachment without a runtime `NetworkID`.

## Tests

- `TestContainers_StoppedContainerInIngressNetworkDoesNotWarn` — in ingress network by ID, no IP → no warning.
- `TestContainers_StoppedContainerMatchesIngressByName` — matched by name → no warning.
- Existing `TestContainers_DifferentNetwork` (genuine mismatch) still warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)