### PR TITLE
chore: trim redundant comments around admin config

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -120,10 +120,8 @@ func buildCaddyRunConfig(options *config.Options) *caddy.Config {
 	}
 }
 
-// buildCaddyAdminConfig builds Caddy's admin config. The admin API is disabled
-// when requested via CADDY_ADMIN=off, or in controller-only mode which serves
-// nothing. A CADDY_ADMIN address or the controller network pick the listen;
-// otherwise Caddy's own default applies (localhost:2019).
+// buildCaddyAdminConfig builds Caddy's admin config: disabled for CADDY_ADMIN=off
+// or controller-only mode, otherwise the configured or default listen.
 func buildCaddyAdminConfig(options *config.Options) *caddy.AdminConfig {
 	if options.AdminDisabled || options.Mode&config.Server != config.Server {
 		return &caddy.AdminConfig{Disabled: true}
@@ -146,8 +144,8 @@ func buildCaddyLoggingConfig(options *config.Options) *caddy.Logging {
 	case "json":
 		defaultLog.EncoderRaw = caddyconfig.JSONModuleObject(caddylogging.JSONEncoder{}, "format", "json", nil)
 	}
-	// When the admin endpoint is disabled - controller-only mode, or CADDY_ADMIN=off -
-	// drop the admin logger so Caddy doesn't warn that it's disabled on every start.
+	// Drop the admin logger when the admin endpoint is disabled, so Caddy doesn't
+	// warn that it's disabled on every start.
 	if options.AdminDisabled || options.Mode&config.Server != config.Server {
 		defaultLog.Exclude = append(defaultLog.Exclude, "admin")
 	}
@@ -157,10 +155,8 @@ func buildCaddyLoggingConfig(options *config.Options) *caddy.Logging {
 	}
 }
 
-// defaultAdminListen is the admin endpoint the plugin falls back to when none is
-// configured. It mirrors Caddy's own default (localhost:2019) in the plugin's
-// canonical "tcp/host:port" form, matching getServerAdminListen and
-// normalizeAdminListen.
+// defaultAdminListen mirrors Caddy's default (localhost:2019) in the plugin's
+// canonical "tcp/host:port" form (as used by getServerAdminListen).
 const defaultAdminListen = "tcp/localhost:2019"
 
 func getAdminListen(options *config.Options) string {
@@ -197,7 +193,6 @@ func getAdminListen(options *config.Options) string {
 			}
 		}
 	}
-	// No listen to enforce: use the default (Caddy's own default, localhost:2019).
 	return defaultAdminListen
 }
 

--- a/loader.go
+++ b/loader.go
@@ -349,13 +349,10 @@ func (dockerLoader *DockerLoader) prepareServerConfig(server string) ([]byte, er
 		return nil, err
 	}
 
-	// Remote servers always need a reachable admin endpoint for controller
-	// pushes, so an absent or disabled admin config falls back to the server
-	// address. The local instance loads in-process and leaves the decision to
-	// the config: an explicit admin config ("admin off" included) is respected,
-	// and an absent one gets Caddy's own default. CADDY_ADMIN supplies the
-	// local listen address or "off" - applied here because Caddy itself has no
-	// disable semantics for that variable.
+	// The local instance loads in-process, so an explicit admin config ("admin
+	// off" included) is respected and only an absent one is filled from
+	// CADDY_ADMIN or the default. Remote servers always need a reachable admin
+	// endpoint for controller pushes, so an absent or disabled one is overridden.
 	if server == localServer {
 		if config.Admin == nil {
 			if dockerLoader.options.AdminDisabled {


### PR DESCRIPTION
Follow-up to #823 (comment-only). Trims comments that restated the code in `buildCaddyAdminConfig`, `buildCaddyLoggingConfig`, `getAdminListen` and `prepareServerConfig`, keeping the ones that explain the non-obvious rationale (why remote always forces an admin endpoint, why the admin logger is dropped, the `tcp/` form of the default).

No behavior change — comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)